### PR TITLE
Fix incorrect source assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,12 +100,12 @@ set(${PROJECT_NAME}_sources
   src/laserscan.cpp
   src/start_request.cpp
   src/stop_request.cpp
+  src/scanner_configuration.cpp
 )
 
 set(${PROJECT_NAME}_node_sources
   src/psen_scan_driver.cpp
   src/ros_parameter_handler.cpp
-  src/scanner_configuration.cpp
 )
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})


### PR DESCRIPTION
The `ScannerConfiguration` source file is currently added to the incorrect target. It must be added to a target a "level" lower, otherwise, the user of the `psen_scan_v2` lib has not all necessary sources available.