### PR TITLE
Remove LaserScan::isNumberOfScansValid

### DIFF
--- a/include/psen_scan_v2/laserscan.h
+++ b/include/psen_scan_v2/laserscan.h
@@ -44,15 +44,11 @@ public:
   const MeasurementData& getMeasurements() const;
   MeasurementData& getMeasurements();
 
-  //! @returns true if the measurement data contain as much measurements as required by the measurement range
-  //! and measurement resolution.
-  bool isNumberOfScansValid() const;
-
 private:
   //! Measurement data of the laserscan (in Millimeters).
   MeasurementData measures_;
   //! Distance of angle between the measurements (in radian).
-  double resolution_;
+  const double resolution_;
   //! Lowest angle the scanner is scanning (in radian).
   const double min_scan_angle_;
   //! Highest angle the scanner is scanning (in radian).

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -93,11 +93,6 @@ sensor_msgs::LaserScan ROSScannerNodeT<S>::toRosMessage(const LaserScan& lasersc
   // TODO Remove after implementing building of laserscans
   // LCOV_EXCL_START
 
-  if (!laserscan.isNumberOfScansValid())
-  {
-    throw std::invalid_argument("Calculated number of scans doesn't match actual number of scans.");
-  }
-
   sensor_msgs::LaserScan ros_message;
   ros_message.header.stamp = ros::Time::now();
   ros_message.header.frame_id = frame_id_;

--- a/src/laserscan.cpp
+++ b/src/laserscan.cpp
@@ -14,9 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <stdexcept>
-#include <cassert>
-#include <limits>
-#include <cmath>
 
 #include "psen_scan_v2/laserscan.h"
 #include "psen_scan_v2/degree_to_rad.h"

--- a/src/laserscan.cpp
+++ b/src/laserscan.cpp
@@ -60,16 +60,6 @@ double LaserScan::getMaxScanAngle() const
   return max_scan_angle_;
 }
 
-bool LaserScan::isNumberOfScansValid() const
-{
-  assert(getMinScanAngle() < getMaxScanAngle() && "Invalid scan range");
-
-  using size_type = MeasurementData::size_type;
-  const auto angle_range{ getMaxScanAngle() - getMinScanAngle() };
-  const size_type expected_size{ static_cast<size_type>(std::floor(angle_range / getScanResolution())) };
-  return measures_.size() == expected_size;
-}
-
 const MeasurementData& LaserScan::getMeasurements() const
 {
   return measures_;

--- a/test/unit_tests/unittest_laserscan.cpp
+++ b/test/unit_tests/unittest_laserscan.cpp
@@ -43,12 +43,6 @@ TEST(LaserScanTests, testInvalidStartEndAngle)
   EXPECT_THROW(LaserScan laser_scan(DEFAULT_RESOLUTION, DEFAULT_END_ANGLE, DEFAULT_START_ANGLE), std::invalid_argument);
 }
 
-TEST(LaserScanTests, testInvalidNumberOfScans)
-{
-  LaserScan laser_scan(DEFAULT_RESOLUTION, DEFAULT_START_ANGLE, DEFAULT_END_ANGLE);
-  EXPECT_FALSE(laser_scan.isNumberOfScansValid());
-}
-
 }  // namespace psen_scan_v2_test
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This method was error-prone and not really necessary for publishing single frames.