### PR TITLE
Add Scanner-API integrationtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,15 @@ if(CATKIN_ENABLE_TESTING)
     ${pilz_testutils_LIBRARIES}
   )
 
+catkin_add_gmock(integrationtest_scanner_api
+  test/integration_tests/integrationtest_scanner_api.cpp
+)
+target_link_libraries(integrationtest_scanner_api
+  ${catkin_LIBRARIES}
+  ${PROJECT_NAME}
+  ${pilz_testutils_LIBRARIES}
+  )
+
   add_rostest_gmock(integrationtest_ros_scanner_node
     test/integration_tests/integrationtest_ros_scanner_node.test
     test/integration_tests/integrationtest_ros_scanner_node.cpp

--- a/test/include/psen_scan_v2/async_barrier.h
+++ b/test/include/psen_scan_v2/async_barrier.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#ifndef PSEN_SCAN_V2_ASYNC_BARRIER_H
+#define PSEN_SCAN_V2_ASYNC_BARRIER_H
+
+#include <future>
+#include <thread>
+#include <chrono>
+
+namespace psen_scan_v2_test
+{
+class Barrier
+{
+public:
+  void release();
+  template <class Rep, class Period>
+  bool waitTillRelease(const std::chrono::duration<Rep, Period>& timeout) const;
+
+private:
+  std::promise<void> barrier_;
+  const std::future<void> future_{ barrier_.get_future() };
+};
+
+void Barrier::release()
+{
+  barrier_.set_value();
+}
+
+template <class Rep, class Period>
+bool Barrier::waitTillRelease(const std::chrono::duration<Rep, Period>& timeout) const
+{
+  return future_.wait_for(timeout) == std::future_status::ready;
+}
+
+}  // namespace psen_scan_v2_test
+
+#endif  // PSEN_SCAN_V2_ASYNC_BARRIER_H

--- a/test/include/psen_scan_v2/mock_udp_server.h
+++ b/test/include/psen_scan_v2/mock_udp_server.h
@@ -46,7 +46,7 @@ public:
 public:
   MockUDPServer(const unsigned short port);
 
-  MOCK_CONST_METHOD1(receivedUdpMsg, void(const udp::endpoint&));
+  MOCK_CONST_METHOD2(receivedUdpMsg, void(const udp::endpoint&, const psen_scan_v2::DynamicSizeRawData&));
 
 public:
   void asyncReceive();
@@ -123,7 +123,8 @@ void MockUDPServer::handleReceive(const boost::system::error_code& error, std::s
     std::cerr << "UDP server mock failed to receive data. Error msg: " << error.message() << std::endl;
     return;
   }
-  receivedUdpMsg(remote_endpoint_);
+  psen_scan_v2::DynamicSizeRawData recv_data(recv_buffer_.cbegin(), recv_buffer_.cbegin() + bytes_received);
+  receivedUdpMsg(remote_endpoint_, recv_data);
 }
 
 void MockUDPServer::asyncReceive()

--- a/test/integration_tests/integrationtest_scanner_api.cpp
+++ b/test/integration_tests/integrationtest_scanner_api.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <future>
+#include <thread>
+#include <chrono>
+#include <functional>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// Test frameworks
+#include "psen_scan_v2/async_barrier.h"
+#include "psen_scan_v2/mock_udp_server.h"
+
+// Software under testing
+#include "psen_scan_v2/scanner_configuration.h"
+#include "psen_scan_v2/scanner.h"
+#include "psen_scan_v2/start_request.h"
+#include "psen_scan_v2/scanner_reply_msg.h"
+
+namespace psen_scan_v2_test
+{
+static const std::string SCANNER_IP_ADDRESS{ "127.0.0.1" };
+static constexpr unsigned short SCANNER_UDP_PORT_CONTROL{ 3000 };
+
+static const std::string HOST_IP_ADDRESS{ "127.0.0.1" };
+static constexpr uint32_t HOST_UDP_PORT_DATA{ 45000 };
+static constexpr uint32_t HOST_UDP_PORT_CONTROL{ 57000 };
+
+static constexpr double START_ANGLE{ 0. };
+static constexpr double END_ANGLE{ 1. };
+
+static constexpr std::chrono::milliseconds WAIT_TIMEOUT{ 10 };
+static constexpr std::chrono::seconds DEFAULT_TIMEOUT{ 3 };
+
+static constexpr uint32_t DEFAULT_SEQ_NUMBER{ 0u };
+
+using namespace psen_scan_v2;
+using namespace ::testing;
+
+class UserCallbacks
+{
+public:
+  MOCK_METHOD1(LaserScanCallback, void(const LaserScan&));
+};
+
+class ScannerMock : public MockUDPServer
+{
+public:
+  ScannerMock();
+
+public:
+  void sendStartReply();
+  void sendStopReply();
+
+private:
+  void sendReply(const uint32_t reply_type);
+
+private:
+  const udp::endpoint host_endpoint_{ udp::endpoint(boost::asio::ip::address_v4::from_string(HOST_IP_ADDRESS),
+                                                    HOST_UDP_PORT_CONTROL) };
+};
+
+ScannerMock::ScannerMock() : MockUDPServer(SCANNER_UDP_PORT_CONTROL)
+{
+}
+
+void ScannerMock::sendReply(const uint32_t reply_type)
+{
+  const ScannerReplyMsg msg(reply_type, 0x00);
+  asyncSend<REPLY_MSG_FROM_SCANNER_SIZE>(host_endpoint_, msg.toRawData());
+}
+
+void ScannerMock::sendStartReply()
+{
+  sendReply(getOpCodeValue(ScannerReplyMsgType::Start));
+}
+
+void ScannerMock::sendStopReply()
+{
+  sendReply(getOpCodeValue(ScannerReplyMsgType::Stop));
+}
+
+ScannerConfiguration createScannerConfig()
+{
+  return ScannerConfiguration(
+      HOST_IP_ADDRESS, HOST_UDP_PORT_DATA, HOST_UDP_PORT_CONTROL, SCANNER_IP_ADDRESS, START_ANGLE, END_ANGLE);
+}
+
+TEST(ScannerAPITests, testStartFunctionality)
+{
+  ScannerMock scanner_mock;
+  const ScannerConfiguration config{ createScannerConfig() };
+  UserCallbacks cb;
+  Scanner scanner(config, std::bind(&UserCallbacks::LaserScanCallback, &cb, std::placeholders::_1));
+  const StartRequest start_req(config, DEFAULT_SEQ_NUMBER);
+
+  Barrier start_req_received_barrier;
+  EXPECT_CALL(scanner_mock, receivedUdpMsg(_, start_req.toRawData()))
+      .WillOnce(InvokeWithoutArgs([&start_req_received_barrier]() { start_req_received_barrier.release(); }));
+
+  scanner_mock.asyncReceive();
+  const auto start_future{ std::async(std::launch::async, [&scanner]() { scanner.start(); }) };
+
+  EXPECT_TRUE(start_req_received_barrier.waitTillRelease(DEFAULT_TIMEOUT)) << "Start request not received";
+  EXPECT_EQ(start_future.wait_for(WAIT_TIMEOUT), std::future_status::timeout) << "Scanner::start() finished too early";
+  scanner_mock.sendStartReply();
+  EXPECT_EQ(start_future.wait_for(DEFAULT_TIMEOUT), std::future_status::ready) << "Scanner::start() not finished";
+}
+
+TEST(ScannerAPITests, testStopFunctionality)
+{
+  ScannerMock scanner_mock;
+  const ScannerConfiguration config{ createScannerConfig() };
+  UserCallbacks cb;
+  Scanner scanner(config, std::bind(&UserCallbacks::LaserScanCallback, &cb, std::placeholders::_1));
+
+  EXPECT_CALL(scanner_mock, receivedUdpMsg(_, StartRequest(config, DEFAULT_SEQ_NUMBER).toRawData()))
+      .WillOnce(InvokeWithoutArgs([&scanner_mock]() { scanner_mock.sendStartReply(); }));
+
+  Barrier stop_req_received_barrier;
+  EXPECT_CALL(scanner_mock, receivedUdpMsg(_, StopRequest().toRawData()))
+      .WillOnce(InvokeWithoutArgs([&stop_req_received_barrier]() { stop_req_received_barrier.release(); }));
+
+  scanner_mock.asyncReceive();
+  scanner.start();
+
+  scanner_mock.asyncReceive();
+  const auto stop_future{ std::async(std::launch::async, [&scanner]() { scanner.stop(); }) };
+
+  EXPECT_TRUE(stop_req_received_barrier.waitTillRelease(DEFAULT_TIMEOUT)) << "Stop request not received";
+  EXPECT_EQ(stop_future.wait_for(WAIT_TIMEOUT), std::future_status::timeout) << "Scanner::stop() finished too early";
+  scanner_mock.sendStopReply();
+  EXPECT_EQ(stop_future.wait_for(DEFAULT_TIMEOUT), std::future_status::ready) << "Scanner::stop() not finished";
+}
+
+}  // namespace psen_scan_v2_test
+
+int main(int argc, char* argv[])
+{
+  testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/unit_tests/unittest_scanner.cpp
+++ b/test/unit_tests/unittest_scanner.cpp
@@ -75,36 +75,6 @@ TEST_F(ScannerTest, testConstructorSuccess)
   EXPECT_NO_THROW(MockedScanner scanner(scanner_config_, laserscan_callback_));
 }
 
-TEST_F(ScannerTest, testStart)
-{
-  MockedScanner scanner(scanner_config_, laserscan_callback_);
-  std::promise<void> mocked_start_finished_barrier;
-  EXPECT_CALL(scanner.scanner_controller_, start()).WillOnce(InvokeWithoutArgs([&mocked_start_finished_barrier]() {
-    return mocked_start_finished_barrier.get_future();
-  }));
-
-  std::future<void> start_future = std::async(std::launch::async, [&scanner]() { scanner.start(); });
-
-  EXPECT_EQ(start_future.wait_for(DEFAULT_TIMEOUT), std::future_status::timeout) << "Scanner::start() already finished";
-  mocked_start_finished_barrier.set_value();
-  EXPECT_EQ(start_future.wait_for(DEFAULT_TIMEOUT), std::future_status::ready) << "Scanner::start() not finished";
-}
-
-TEST_F(ScannerTest, testStop)
-{
-  MockedScanner scanner(scanner_config_, laserscan_callback_);
-  std::promise<void> mocked_stop_finished_barrier;
-  EXPECT_CALL(scanner.scanner_controller_, stop()).WillOnce(InvokeWithoutArgs([&mocked_stop_finished_barrier]() {
-    return mocked_stop_finished_barrier.get_future();
-  }));
-
-  std::future<void> stop_future = std::async(std::launch::async, [&scanner]() { scanner.stop(); });
-
-  EXPECT_EQ(stop_future.wait_for(DEFAULT_TIMEOUT), std::future_status::timeout) << "Scanner::stop() already finished";
-  mocked_stop_finished_barrier.set_value();
-  EXPECT_EQ(stop_future.wait_for(DEFAULT_TIMEOUT), std::future_status::ready) << "Scanner::stop() not finished";
-}
-
 TEST_F(ScannerTest, testInvokeLaserScanCallback)
 {
   LaserScan laser_scan_fake(0.02, 0.03, 0.05);


### PR DESCRIPTION
This PR adds an integration-test which uses all "real" software components of the overall system and simulates the real hardware scanner with a mocked UDP server.

**Note:**
This PR results from the observation that changes to the code base can be made without detecting that the existing functionality was broken.

**Note:**
This PR requires the following PR's to be merged first (rebase this PR than => CI will be green):
- [x] PR #24