### PR TITLE
Consolidate raw OPCode value and ReplyMsgType

### DIFF
--- a/include/psen_scan_v2/scanner_reply_msg.h
+++ b/include/psen_scan_v2/scanner_reply_msg.h
@@ -32,12 +32,18 @@ namespace psen_scan_v2
 /**
  * @brief Defines the possible types of reply messages which can be received from the scanner.
  */
-enum class ScannerReplyMsgType
+enum class ScannerReplyMsgType : uint32_t
 {
-  Start,
-  Stop,
-  Unknown
+  Unknown = 0,
+  Start = 0x35,
+  Stop = 0x36,
 };
+
+template <typename TEnum>
+auto getOpCodeValue(const TEnum value) -> typename std::underlying_type<TEnum>::type
+{
+  return static_cast<typename std::underlying_type<TEnum>::type>(value);
+}
 
 static constexpr std::size_t REPLY_MSG_FROM_SCANNER_SIZE = 16;  // See protocol description
 
@@ -66,8 +72,6 @@ public:
   ScannerReplyMsgType type() const;
 
 public:
-  static uint32_t getStartOpCode();
-  static uint32_t getStopOpCode();
   static uint32_t calcCRC(const ScannerReplyMsg& msg);
 
   using RawType = FixedSizeRawData<REPLY_MSG_FROM_SCANNER_SIZE>;
@@ -92,10 +96,6 @@ private:
   //! If the message is refused, the returned value is 0xEB.
   //! If the CRC is not correct, the device will not send any message.
   uint32_t res_code_{ 0 };
-
-private:
-  static constexpr uint32_t OPCODE_START{ 0x35 };
-  static constexpr uint32_t OPCODE_STOP{ 0x36 };
 };
 
 inline uint32_t ScannerReplyMsg::calcCRC(const ScannerReplyMsg& msg)
@@ -113,16 +113,6 @@ template <typename T>
 inline void ScannerReplyMsg::processBytes(boost::crc_32_type& crc_32, const T& data)
 {
   crc_32.process_bytes(&data, sizeof(T));
-}
-
-inline uint32_t ScannerReplyMsg::getStartOpCode()
-{
-  return OPCODE_START;
-}
-
-inline uint32_t ScannerReplyMsg::getStopOpCode()
-{
-  return OPCODE_STOP;
 }
 
 inline ScannerReplyMsg::ScannerReplyMsg(const uint32_t op_code, const uint32_t res_code)
@@ -163,12 +153,12 @@ inline void ScannerReplyMsg::read(std::istringstream& is, T& data)
 
 inline ScannerReplyMsgType ScannerReplyMsg::type() const
 {
-  if (opcode_ == OPCODE_START)
+  if (opcode_ == getOpCodeValue(ScannerReplyMsgType::Start))
   {
     return ScannerReplyMsgType::Start;
   }
 
-  if (opcode_ == OPCODE_STOP)
+  if (opcode_ == getOpCodeValue(ScannerReplyMsgType::Stop))
   {
     return ScannerReplyMsgType::Stop;
   }

--- a/test/unit_tests/unittest_msg_decoder.cpp
+++ b/test/unit_tests/unittest_msg_decoder.cpp
@@ -58,7 +58,7 @@ TEST_F(MsgDecoderTest, testCorrectStartReply)
   EXPECT_CALL(mock_, start_reply_callback()).Times(1);
   EXPECT_CALL(mock_, stop_reply_callback()).Times(0);
 
-  const auto raw_start_reply{ buildRawData(ScannerReplyMsg::getStartOpCode(), DEFAULT_RESULT_CODE) };
+  const auto raw_start_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Start), DEFAULT_RESULT_CODE) };
   decoder_.decodeAndDispatch(raw_start_reply, REPLY_MSG_FROM_SCANNER_SIZE);
 }
 
@@ -67,7 +67,7 @@ TEST_F(MsgDecoderTest, testCorrectStopReply)
   EXPECT_CALL(mock_, start_reply_callback()).Times(0);
   EXPECT_CALL(mock_, stop_reply_callback()).Times(1);
 
-  const auto raw_stop_reply{ buildRawData(ScannerReplyMsg::getStopOpCode(), DEFAULT_RESULT_CODE) };
+  const auto raw_stop_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Stop), DEFAULT_RESULT_CODE) };
   decoder_.decodeAndDispatch(raw_stop_reply, REPLY_MSG_FROM_SCANNER_SIZE);
 }
 
@@ -75,7 +75,7 @@ TEST_F(MsgDecoderTest, testIncorrectCrCForStartReply)
 {
   EXPECT_CALL(mock_, start_reply_callback()).Times(0);
 
-  auto raw_reply{ buildRawData(ScannerReplyMsg::getStartOpCode(), DEFAULT_RESULT_CODE) };
+  auto raw_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Start), DEFAULT_RESULT_CODE) };
   raw_reply[0] = 'a';
   EXPECT_THROW(decoder_.decodeAndDispatch(raw_reply, REPLY_MSG_FROM_SCANNER_SIZE), CRCMismatch);
 }
@@ -84,7 +84,7 @@ TEST_F(MsgDecoderTest, testIncorrectCrCForStopReply)
 {
   EXPECT_CALL(mock_, stop_reply_callback()).Times(0);
 
-  auto raw_reply{ buildRawData(ScannerReplyMsg::getStopOpCode(), DEFAULT_RESULT_CODE) };
+  auto raw_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Stop), DEFAULT_RESULT_CODE) };
   raw_reply[0] = 'a';
   EXPECT_THROW(decoder_.decodeAndDispatch(raw_reply, REPLY_MSG_FROM_SCANNER_SIZE), CRCMismatch);
 }
@@ -94,7 +94,7 @@ TEST_F(MsgDecoderTest, testIncorrectReplySize)
   EXPECT_CALL(mock_, start_reply_callback()).Times(0);
   EXPECT_CALL(mock_, error_callback(::testing::_)).Times(1);
 
-  const auto raw_reply{ buildRawData(ScannerReplyMsg::getStartOpCode(), DEFAULT_RESULT_CODE) };
+  const auto raw_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Start), DEFAULT_RESULT_CODE) };
   decoder_.decodeAndDispatch(raw_reply, REPLY_MSG_FROM_SCANNER_SIZE + 1);
 }
 
@@ -103,7 +103,7 @@ TEST_F(MsgDecoderTest, testIncorrectOPCode)
   EXPECT_CALL(mock_, start_reply_callback()).Times(0);
   EXPECT_CALL(mock_, error_callback(::testing::_)).Times(1);
 
-  const auto raw_wrong_reply{ buildRawData(ScannerReplyMsg::getStartOpCode() + 10, DEFAULT_RESULT_CODE) };
+  const auto raw_wrong_reply{ buildRawData(getOpCodeValue(ScannerReplyMsgType::Start) + 10, DEFAULT_RESULT_CODE) };
   decoder_.decodeAndDispatch(raw_wrong_reply, REPLY_MSG_FROM_SCANNER_SIZE);
 }
 

--- a/test/unit_tests/unittest_scanner_reply_msg.cpp
+++ b/test/unit_tests/unittest_scanner_reply_msg.cpp
@@ -47,7 +47,7 @@ TEST(ScannerReplyMsgTest, testTypeUnknown)
 
 TEST(ScannerReplyMsgTest, testGetStartOpCode)
 {
-  EXPECT_EQ(OP_CODE_START, ScannerReplyMsg::getStartOpCode());
+  EXPECT_EQ(OP_CODE_START, getOpCodeValue(ScannerReplyMsgType::Start));
 }
 
 TEST(ScannerReplyMsgTest, testtoRawData)


### PR DESCRIPTION
This PR removes the error-prone separation of `ScannerReplyMsgType` and the corresponding OpCode values.