### PR TITLE
clang-tidy fixes

### DIFF
--- a/include/psen_scan_v2/start_request.h
+++ b/include/psen_scan_v2/start_request.h
@@ -94,7 +94,7 @@ private:
     };
 
   private:
-    const DefaultScanRange scan_range_;
+    const DefaultScanRange scan_range_{};
     double resolution_{ 0. };
   };
 

--- a/test/unit_tests/unittest_scanner.cpp
+++ b/test/unit_tests/unittest_scanner.cpp
@@ -46,8 +46,6 @@ static constexpr int HOST_UDP_PORT_CONTROL{ 55055 };
 static const std::string DEVICE_IP{ "127.0.0.100" };
 static constexpr DefaultScanRange SCAN_RANGE{ TenthOfDegree(0), TenthOfDegree(2750) };
 
-static constexpr std::chrono::milliseconds DEFAULT_TIMEOUT{ 50 };
-
 class ScannerTest : public testing::Test
 {
 protected:

--- a/test/unit_tests/unittest_tenth_of_degree.cpp
+++ b/test/unit_tests/unittest_tenth_of_degree.cpp
@@ -22,11 +22,6 @@ using namespace psen_scan_v2;
 
 namespace psen_scan_v2_test
 {
-TEST(TenthOfDegreeTest, constructorTest)
-{
-  TenthOfDegree tenth_of_degree{ 1 };
-}
-
 TEST(TenthOfDegreeTest, valueTest)
 {
   TenthOfDegree tenth_of_degree{ 1 };


### PR DESCRIPTION
Check with
```
catkin_make -DCATKIN_ENABLE_CLANG_TIDY=True
catkin_make tests -DCATKIN_ENABLE_CLANG_TIDY=True
```