### PR TITLE
Add CTor for MonitoringFrameMsg

### DIFF
--- a/include/psen_scan_v2/monitoring_frame_msg.h
+++ b/include/psen_scan_v2/monitoring_frame_msg.h
@@ -83,6 +83,17 @@ public:
   };
 
 public:
+  MonitoringFrameMsg() = default;
+  MonitoringFrameMsg(const TenthOfDegree& from_theta,
+                     const TenthOfDegree& resolution,
+                     const uint32_t scan_counter,
+                     const std::vector<double> measures)
+    : from_theta_fixed_(from_theta)
+    , resolution_fixed_(resolution)
+    , scan_counter_(scan_counter)
+    , measures_(measures){
+
+    };
   static MonitoringFrameMsg deserialize(const MaxSizeRawData& data, const std::size_t& num_bytes);
 
 public:
@@ -90,6 +101,12 @@ public:
   TenthOfDegree resolution() const;
   uint32_t scanCounter() const;
   std::vector<double> measures() const;
+
+  bool operator==(const MonitoringFrameMsg& rhs) const
+  {
+    return (fromTheta() == rhs.fromTheta() && resolution() == rhs.resolution() && scanCounter() == rhs.scanCounter() &&
+            measures() == rhs.measures());
+  }
 
 private:
   using FieldId = FieldHeader::Id;
@@ -110,9 +127,9 @@ private:
 
 private:
   uint32_t device_status_fixed_{ 0 };
-  uint32_t op_code_fixed_{ 0 };
+  uint32_t op_code_fixed_{ OP_CODE_MONITORING_FRAME };
   uint32_t working_mode_fixed_{ 0 };
-  uint32_t transaction_type_fixed_{ 0 };
+  uint32_t transaction_type_fixed_{ GUI_MONITORING_TRANSACTION };
   uint8_t scanner_id_fixed_{ 0 };
   TenthOfDegree from_theta_fixed_{ 0 };
   TenthOfDegree resolution_fixed_{ 0 };

--- a/test/integration_tests/integrationtest_scanner_api.cpp
+++ b/test/integration_tests/integrationtest_scanner_api.cpp
@@ -119,7 +119,7 @@ void ScannerMock::sendStopReply()
 
 void ScannerMock::sendMonitoringFrame()
 {
-  constexpr UDPFrameTestDataWithoutIntensities raw_scan;
+  const UDPFrameTestDataWithoutIntensities raw_scan;
   data_server_.asyncSend<raw_scan.hex_dump.size()>(monitoring_frame_receiver_, transformArray(raw_scan.hex_dump));
 }
 

--- a/test/unit_tests/unittest_monitoring_frame_msg.cpp
+++ b/test/unit_tests/unittest_monitoring_frame_msg.cpp
@@ -110,21 +110,12 @@ protected:
   std::size_t num_bytes_{ 2 * test_data_.hex_dump.size() };
 };
 
-TEST_F(MonitoringFrameMsgFromRawTest, testReadSuccess)
+TEST_F(MonitoringFrameMsgFromRawTest, testDeserializationSuccess)
 {
   MonitoringFrameMsg msg;
   ASSERT_NO_THROW(msg = MonitoringFrameMsg::deserialize(raw_frame_data_, num_bytes_););
 
-  EXPECT_EQ(msg.fromTheta().value(), test_data_.from_theta);
-  EXPECT_EQ(msg.resolution().value(), test_data_.resolution);
-  EXPECT_EQ(msg.scanCounter(), test_data_.scan_counter);
-
-  const auto measures = msg.measures();
-  EXPECT_EQ(measures.size(), test_data_.number_of_measures);
-  for (const auto& index_value_pair : test_data_.measures)
-  {
-    EXPECT_DOUBLE_EQ(measures.at(index_value_pair.first), index_value_pair.second / 1000.);
-  }
+  EXPECT_EQ(msg, test_data_.msg_);
 }
 
 TEST_F(MonitoringFrameMsgFromRawTest, testWrongOpCode)

--- a/test/unit_tests/unittest_monitoring_frame_serialization.cpp
+++ b/test/unit_tests/unittest_monitoring_frame_serialization.cpp
@@ -26,22 +26,41 @@ namespace psen_scan_v2_test
 {
 TEST(MonitoringFrameSerializationTest, testUDPFrameTestDataWithoutIntensitiesSuccess)
 {
+  // Load testdata from dump
   UDPFrameTestDataWithoutIntensities test_data;
-  MaxSizeRawData monitoring_frame_without_intensities_raw = convertToMaxSizeRawData(test_data.hex_dump);
 
-  MonitoringFrameMsg monitoring_frame_message =
-      MonitoringFrameMsg::deserialize(monitoring_frame_without_intensities_raw, test_data.hex_dump.size());
-  DynamicSizeRawData serialized_monitoring_frame_message = serialize(monitoring_frame_message);
+  // Serialize the message
+  DynamicSizeRawData serialized_monitoring_frame_message = serialize(test_data.msg_);
 
   EXPECT_EQ(test_data.hex_dump.size(), serialized_monitoring_frame_message.size());
 
   for (size_t i = 0; i < test_data.hex_dump.size(); i++)
   {
-    uint8_t hex_dump_byte = test_data.hex_dump.at(i);
-    uint8_t serialized_monitoring_frame_message_byte = serialized_monitoring_frame_message.at(i);
-    EXPECT_EQ(serialized_monitoring_frame_message_byte, hex_dump_byte);
+    EXPECT_EQ((uint8_t)serialized_monitoring_frame_message.at(i), test_data.hex_dump.at(i)) << " index " << i;
   }
 }
+
+TEST(MonitoringFrameSerializationTest, testSerializationInvariance)
+{
+  UDPFrameTestDataWithoutIntensities test_data;
+  DynamicSizeRawData raw = serialize(test_data.msg_);
+
+  MonitoringFrameMsg deserialized_msg = MonitoringFrameMsg::deserialize(convertToMaxSizeRawData(raw), raw.size());
+
+  EXPECT_EQ(test_data.msg_, deserialized_msg);
+}
+
+TEST(MonitoringFrameSerializationTest, testSerializationInvariance2)
+{
+  MonitoringFrameMsg msg(TenthOfDegree(25), TenthOfDegree(1), 456, { 10, 20, 30, 40 });
+
+  DynamicSizeRawData raw = serialize(msg);
+
+  MonitoringFrameMsg deserialized_msg = MonitoringFrameMsg::deserialize(convertToMaxSizeRawData(raw), raw.size());
+
+  EXPECT_EQ(msg, deserialized_msg);
+}
+
 }  // namespace psen_scan_v2_test
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Add a CTOR to MonitoringFrameMsg. With this the usage of the raw hex dumps should be reduced in upcoming PRs.