### PR TITLE
Adds scanner started msg

### DIFF
--- a/include/psen_scan_v2/scanner_controller.h
+++ b/include/psen_scan_v2/scanner_controller.h
@@ -226,7 +226,7 @@ void ScannerControllerT<TCSM, TUCI>::sendStopRequest()
 template <typename TCSM, typename TUCI>
 void ScannerControllerT<TCSM, TUCI>::notifyStartedState()
 {
-  PSENSCAN_DEBUG("ScannerController", "Started() called.");
+  PSENSCAN_INFO("ScannerController", "Scanner started successfully.");
   stopStartReplyWatchdog();
 
   started_.set_value();


### PR DESCRIPTION
Changes a debug lvl msg to info to notify the user of a successful start of the scanner.

This is in particular useful when the start was not successful right away. 