### PR TITLE
Closes data udp connection on stop

### DIFF
--- a/include/psen_scan_v2/scanner_controller.h
+++ b/include/psen_scan_v2/scanner_controller.h
@@ -216,7 +216,7 @@ void ScannerControllerT<TCSM, TUCI>::sendStopRequest()
 {
   // Before we send the stop request, we need to ensure that an potentially running start()-loop is stopped.
   stopStartReplyWatchdog();
-
+  data_udp_client_.close();
   control_udp_client_.startAsyncReceiving(
       ReceiveMode::single, std::bind(&ScannerControllerT::handleStopReplyTimeout, this, _1), RECEIVE_TIMEOUT_CONTROL);
   StopRequest stop_request;


### PR DESCRIPTION
Should fix the issue of a waning popping up on every shutdown.


Before (occasionally):
```bash
[ INFO] [1603090991.474239786]: Start scanner called.
[ INFO] [1603090991.477416409]: Scanner started successfully.
^C[rviz-3] killing on exit
[laser_scanner-2] killing on exit
[ INFO] [1603090995.474167950]: Stop scanner called.
[ WARN] [1603090995.474580951]: Received monitoring frame despite not waiting for it (in State 3)   // <-Not good
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```

After:
```bash
[ INFO] [1603090982.681571324]: Start scanner called.
[ INFO] [1603090982.683177099]: Scanner started successfully.
^C[rviz-3] killing on exit
[laser_scanner-2] killing on exit
[ INFO] [1603090983.781547981]: Stop scanner called.
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```