### PR TITLE
Fix/multi start

### DIFF
--- a/include/psen_scan_v2/scanner_state_machine.h
+++ b/include/psen_scan_v2/scanner_state_machine.h
@@ -121,6 +121,7 @@ public:  // Action methods
   void handleStartRequestTimeout(const scanner_events::StartTimeout& event);
   void sendStopRequest(const scanner_events::StopRequest& event);
   void handleMonitoringFrame(const scanner_events::RawMonitoringFrameReceived& event);
+  void notifyAlreadyStarted(const scanner_events::StartRequest& event);
 
 public:  // Guards
   bool isStartReply(scanner_events::RawReplyReceived const& reply_event);
@@ -146,6 +147,8 @@ public:  // Definition of state machine via table
       g_row  < WaitForStartReply,         e::RawReplyReceived,          WaitForMonitoringFrame,                                   &m::isStartReply            >,
       a_irow < WaitForStartReply,         e::StartTimeout,                                          &m::handleStartRequestTimeout                             >,
       a_irow < WaitForMonitoringFrame,    e::RawMonitoringFrameReceived,                            &m::handleMonitoringFrame                                 >,
+      a_irow < WaitForStartReply,         e::StartRequest,                                          &m::notifyAlreadyStarted                                  >,
+      a_irow < WaitForMonitoringFrame,    e::StartRequest,                                          &m::notifyAlreadyStarted                                  >,
       a_row  < WaitForStartReply,         e::StopRequest,               WaitForStopReply,           &m::sendStopRequest                                       >,
       a_row  < WaitForMonitoringFrame,    e::StopRequest,               WaitForStopReply,           &m::sendStopRequest                                       >,
       g_row  < WaitForStopReply,          e::RawReplyReceived,          Stopped,                                                  &m::isStopReply             >

--- a/include/psen_scan_v2/scanner_state_machine.hpp
+++ b/include/psen_scan_v2/scanner_state_machine.hpp
@@ -106,6 +106,11 @@ inline void ScannerProtocolDef::handleMonitoringFrame(const scanner_events::RawM
   args_->inform_user_about_laser_scan_cb(toLaserScan(frame));
 }
 
+inline void ScannerProtocolDef::notifyAlreadyStarted(const scanner_events::StartRequest& event)
+{
+  PSENSCAN_WARN("StateMachine", "Start called on running scanner.");
+}
+
 //+++++++++++++++++++++++++++++++++ Guards ++++++++++++++++++++++++++++++++++++
 
 inline bool ScannerProtocolDef::isStartReply(scanner_events::RawReplyReceived const& reply_event)

--- a/include/psen_scan_v2/scanner_v2.h
+++ b/include/psen_scan_v2/scanner_v2.h
@@ -76,7 +76,7 @@ private:
   void stopStartWatchdog();
 
 private:
-  std::promise<void> scanner_has_started_;
+  std::vector<std::promise<void>> scanner_has_started_;
   std::promise<void> scanner_has_stopped_;
 
   // The watchdog pointer is changed by the user-main-thread and by the UDP client callback-thread/io-service-thread,

--- a/include/psen_scan_v2/udp_connection_state_machine.h
+++ b/include/psen_scan_v2/udp_connection_state_machine.h
@@ -230,6 +230,7 @@ struct udp_connection_state_machine_ : public msm::front::state_machine_def<udp_
       row  < s::wait_for_start_reply,       e::reply_received,               s::wait_for_monitoring_frame,   &m::action_notify_start,            &m::guard_is_start_reply  >,
     a_irow < s::wait_for_monitoring_frame,  e::monitoring_frame_received,                                    &m::action_handle_monitoring_frame                            >,
     a_irow < s::wait_for_start_reply,       e::start_reply_timeout,                                          &m::action_send_start_request                                 >,
+    _irow  < s::wait_for_start_reply,       e::start_request,                                                                                                              >,
     a_row  < s::wait_for_start_reply,       e::stop_request,                 s::wait_for_stop_reply,         &m::action_send_stop_request                                  >,
     a_row  < s::wait_for_monitoring_frame,  e::stop_request,                 s::wait_for_stop_reply,         &m::action_send_stop_request                                  >,
       row  < s::wait_for_stop_reply,        e::reply_received,               s::stopped,                     &m::action_notify_stop,             &m::guard_is_stop_reply   >


### PR DESCRIPTION
This PR tries to remedy the issues which occur if `Scanner::start()` is called twice.