### PR TITLE
Fixes failure when smaller scan range

### DIFF
--- a/include/psen_scan_v2/laserscan_conversions.h
+++ b/include/psen_scan_v2/laserscan_conversions.h
@@ -27,7 +27,7 @@ static LaserScan toLaserScan(const MonitoringFrameMsg& frame)
   const auto resolution = frame.resolution();
   const auto min_angle = frame.fromTheta();
   const uint16_t number_of_samples = frame.measures().size();
-  const auto max_angle = (frame.fromTheta() + frame.resolution() * (number_of_samples - 1u));
+  const auto max_angle = (frame.fromTheta() + frame.resolution() * number_of_samples);
 
   LaserScan scan(resolution, min_angle, max_angle);
   scan.setMeasurements(frame.measures());

--- a/include/psen_scan_v2/scan_range.h
+++ b/include/psen_scan_v2/scan_range.h
@@ -68,7 +68,7 @@ constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_
 
   if (start_angle > end_angle)
   {
-    throw std::invalid_argument("End angle must not be smaller than start angle");
+    throw std::invalid_argument("Start angle must be smaller than end angle");
   }
 }
 

--- a/include/psen_scan_v2/scan_range.h
+++ b/include/psen_scan_v2/scan_range.h
@@ -68,7 +68,7 @@ constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_
 
   if (start_angle > end_angle)
   {
-    throw std::invalid_argument("Start angle must be smaller than end angle");
+    throw std::invalid_argument("Start angle must be smaller or equal to end angle");
   }
 }
 

--- a/src/laserscan.cpp
+++ b/src/laserscan.cpp
@@ -38,9 +38,9 @@ LaserScan::LaserScan(const TenthOfDegree& resolution,
     throw std::invalid_argument("Resolution out of possible angle range");
   }
 
-  if (getMinScanAngle() >= getMaxScanAngle())
+  if (getMinScanAngle() > getMaxScanAngle())
   {
-    throw std::invalid_argument("Attention: Start angle has to be smaller than end angle!");
+    throw std::invalid_argument("Attention: Start angle has to be smaller or equal to the end angle!");
   }
 }
 

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -69,10 +69,10 @@ int main(int argc, char** argv)
   try
   {
     DefaultScanRange scan_range{
-      TenthOfDegree::fromRad(DEFAULT_X_AXIS_ROTATION -
-                             getOptionalParamFromServer<double>(pnh, PARAM_ANGLE_END, DEFAULT_ANGLE_END)),
-      TenthOfDegree::fromRad(DEFAULT_X_AXIS_ROTATION -
-                             getOptionalParamFromServer<double>(pnh, PARAM_ANGLE_START, DEFAULT_ANGLE_START))
+      TenthOfDegree::fromRad(DEFAULT_X_AXIS_ROTATION +
+                             getOptionalParamFromServer<double>(pnh, PARAM_ANGLE_START, DEFAULT_ANGLE_START)),
+      TenthOfDegree::fromRad(DEFAULT_X_AXIS_ROTATION +
+                             getOptionalParamFromServer<double>(pnh, PARAM_ANGLE_END, DEFAULT_ANGLE_END))
     };
 
     ScannerConfiguration scanner_configuration(getRequiredParamFromServer<std::string>(pnh, PARAM_HOST_IP),

--- a/test/unit_tests/unittest_laserscan.cpp
+++ b/test/unit_tests/unittest_laserscan.cpp
@@ -73,7 +73,6 @@ TEST(LaserScanTest, testGetMaxScanAngle)
 
 TEST(LaserScanTest, testMinEqualsMax)
 {
-  const auto expected_max_scan_angle{ DEFAULT_END_ANGLE };
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u))););
 }

--- a/test/unit_tests/unittest_laserscan.cpp
+++ b/test/unit_tests/unittest_laserscan.cpp
@@ -73,7 +73,7 @@ TEST(LaserScanTest, testGetMaxScanAngle)
 
 TEST(LaserScanTest, testMinEqualsMax)
 {
-ASSERT_NO_THROW(LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u)););
+  ASSERT_NO_THROW(LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u)););
 }
 
 }  // namespace psen_scan_v2_test

--- a/test/unit_tests/unittest_laserscan.cpp
+++ b/test/unit_tests/unittest_laserscan.cpp
@@ -71,6 +71,13 @@ TEST(LaserScanTest, testGetMaxScanAngle)
   EXPECT_EQ(expected_max_scan_angle, laser_scan->getMaxScanAngle());
 }
 
+TEST(LaserScanTest, testMinEqualsMax)
+{
+  const auto expected_max_scan_angle{ DEFAULT_END_ANGLE };
+  std::unique_ptr<LaserScan> laser_scan;
+  ASSERT_NO_THROW(laser_scan.reset(new LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u))););
+}
+
 }  // namespace psen_scan_v2_test
 
 int main(int argc, char** argv)

--- a/test/unit_tests/unittest_laserscan.cpp
+++ b/test/unit_tests/unittest_laserscan.cpp
@@ -73,8 +73,7 @@ TEST(LaserScanTest, testGetMaxScanAngle)
 
 TEST(LaserScanTest, testMinEqualsMax)
 {
-  std::unique_ptr<LaserScan> laser_scan;
-  ASSERT_NO_THROW(laser_scan.reset(new LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u))););
+ASSERT_NO_THROW(LaserScan(DEFAULT_RESOLUTION, TenthOfDegree(1000u), TenthOfDegree(1000u)););
 }
 
 }  // namespace psen_scan_v2_test

--- a/test/unit_tests/unittest_laserscan_conversions.cpp
+++ b/test/unit_tests/unittest_laserscan_conversions.cpp
@@ -58,8 +58,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectMinMaxScanAngleAfter
   std::unique_ptr<LaserScan> scan_ptr;
   ASSERT_NO_THROW(scan_ptr.reset(new LaserScan{ toLaserScan(frame) }););
 
-  const TenthOfDegree expected_max_scan_angle{ (frame.fromTheta() +
-                                                frame.resolution() * (frame.measures().size() - 1)) };
+  const TenthOfDegree expected_max_scan_angle{ frame.fromTheta() + frame.resolution() * frame.measures().size() };
 
   EXPECT_EQ(frame.fromTheta(), scan_ptr->getMinScanAngle()) << "Min scan-angle incorrect in LaserScan";
   EXPECT_EQ(expected_max_scan_angle, scan_ptr->getMaxScanAngle()) << "Max scan-angle incorrect in LaserScan";


### PR DESCRIPTION
Fixes an error
```
[ INFO] [1603792097.975607951]: Start scanner called.
[ WARN] [1603792097.977530696]: Received monitoring frame despite not waiting for it
[ INFO] [1603792097.978471639]: Scanner started successfully.
[ WARN] [1603792097.981032962]: The scanner reports an error: {Device: Master - Error in the External Device Monitoring (EDM1_ERR).}
psen_scan_v2_node: /usr/include/boost/msm/front/state_machine_def.hpp:209: void boost::msm::front::state_machine_def<Derived, BaseState>::exception_caught(const Event&, FSM&, std::exception&) [with FSM = boost::msm::back::state_machine<psen_scan_v2::scanner_protocol::ScannerProtocolDef>; Event = psen_scan_v2::scanner_protocol::scanner_events::RawMonitoringFrameReceived; Derived = psen_scan_v2::scanner_protocol::ScannerProtocolDef; BaseState = boost::msm::front::default_base_state]: Assertion `false' failed.
process[rviz-4]: started with pid [21645]
```
when using a smaller scan range.