### PR TITLE
Use signed integer type for representing angles in tenth degree

### DIFF
--- a/include/psen_scan_v2/angle_conversions.h
+++ b/include/psen_scan_v2/angle_conversions.h
@@ -16,6 +16,9 @@
 #ifndef PSEN_SCAN_V2_ANGLE_CONVERSIONS_H
 #define PSEN_SCAN_V2_ANGLE_CONVERSIONS_H
 
+#include <sstream>
+#include <stdexcept>
+
 #include <boost/math/constants/constants.hpp>
 
 namespace psen_scan_v2
@@ -30,25 +33,25 @@ inline static constexpr double degreeToRadian(const double& angle_in_degree)
   return (angle_in_degree / 180.) * boost::math::double_constants::pi;
 }
 
-inline static uint16_t degreeToTenthDegree(const double& angle_in_degree)
+inline static int16_t degreeToTenthDegree(const double& angle_in_degree)
 {
   const double tenth_degree_rounded{ std::round(10. * angle_in_degree) };
-  if (tenth_degree_rounded < std::numeric_limits<uint16_t>::min() ||
-      tenth_degree_rounded > std::numeric_limits<uint16_t>::max())
+  if (tenth_degree_rounded < std::numeric_limits<int16_t>::min() ||
+      tenth_degree_rounded > std::numeric_limits<int16_t>::max())
   {
     std::stringstream exception_msg;
     exception_msg << "Angle " << tenth_degree_rounded << " (tenth of degree) is out of range.";
     throw std::invalid_argument(exception_msg.str());
   }
-  return static_cast<uint16_t>(tenth_degree_rounded);
+  return static_cast<int16_t>(tenth_degree_rounded);
 }
 
-inline static uint16_t radToTenthDegree(const double& angle_in_rad)
+inline static int16_t radToTenthDegree(const double& angle_in_rad)
 {
   return degreeToTenthDegree(radianToDegree(angle_in_rad));
 }
 
-inline static double constexpr tenthDegreeToRad(const uint16_t& angle_in_tenth_degree)
+inline static double constexpr tenthDegreeToRad(const int16_t& angle_in_tenth_degree)
 {
   return degreeToRadian(static_cast<double>(angle_in_tenth_degree) / 10.);
 }

--- a/include/psen_scan_v2/scan_range.h
+++ b/include/psen_scan_v2/scan_range.h
@@ -25,7 +25,7 @@ namespace psen_scan_v2
 /**
  * @brief Higher level data type storing the range in which the scanner takes measurements.
  */
-template <uint16_t min_allowed_angle, uint16_t max_allowed_angle>
+template <int16_t min_allowed_angle, int16_t max_allowed_angle>
 class ScanRange
 {
   static_assert(min_allowed_angle < max_allowed_angle, "MIN-angle limit smaller than MAX-angle limit.");
@@ -52,7 +52,7 @@ private:
   const TenthOfDegree MAX_ANGLE{ max_allowed_angle };
 };
 
-template <uint16_t min_angle, uint16_t max_angle>
+template <int16_t min_angle, int16_t max_angle>
 constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_angle, const TenthOfDegree& end_angle)
   : start_angle_(start_angle), end_angle_(end_angle)
 {
@@ -72,13 +72,13 @@ constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_
   }
 }
 
-template <uint16_t min_angle, uint16_t max_angle>
+template <int16_t min_angle, int16_t max_angle>
 const TenthOfDegree& ScanRange<min_angle, max_angle>::getStart() const
 {
   return start_angle_;
 }
 
-template <uint16_t min_angle, uint16_t max_angle>
+template <int16_t min_angle, int16_t max_angle>
 const TenthOfDegree& ScanRange<min_angle, max_angle>::getEnd() const
 {
   return end_angle_;

--- a/include/psen_scan_v2/tenth_of_degree.h
+++ b/include/psen_scan_v2/tenth_of_degree.h
@@ -29,11 +29,11 @@ public:
   }
 
 public:
-  explicit constexpr TenthOfDegree(const uint16_t& tenth_of_degree) : tenth_of_degree_(tenth_of_degree)
+  explicit constexpr TenthOfDegree(const int16_t& tenth_of_degree) : tenth_of_degree_(tenth_of_degree)
   {
   }
 
-  constexpr uint16_t value() const
+  constexpr int16_t value() const
   {
     return tenth_of_degree_;
   }
@@ -49,7 +49,7 @@ public:
     return *this;
   }
 
-  constexpr TenthOfDegree& operator*(const unsigned int& rhs)
+  constexpr TenthOfDegree& operator*(const int& rhs)
   {
     tenth_of_degree_ = value() * rhs;
     return *this;
@@ -87,7 +87,7 @@ public:
   }
 
 private:
-  uint16_t tenth_of_degree_{ 0 };
+  int16_t tenth_of_degree_{ 0 };
 };
 }  // namespace psen_scan_v2
 

--- a/src/monitoring_frame_deserialization.cpp
+++ b/src/monitoring_frame_deserialization.cpp
@@ -175,8 +175,8 @@ FixedFields readFixedFields(std::istringstream& is)
   raw_processing::read(is, transaction_type);
   raw_processing::read(is, scanner_id);
 
-  raw_processing::read<uint16_t, TenthOfDegree>(is, from_theta);
-  raw_processing::read<uint16_t, TenthOfDegree>(is, resolution);
+  raw_processing::read<int16_t, TenthOfDegree>(is, from_theta);
+  raw_processing::read<int16_t, TenthOfDegree>(is, resolution);
 
   if (OP_CODE_MONITORING_FRAME != op_code)
   {

--- a/src/start_request.cpp
+++ b/src/start_request.cpp
@@ -76,18 +76,18 @@ DynamicSizeRawData StartRequest::serialize() const
   raw_processing::write(os, speed_encoder_enabled_);
   raw_processing::write(os, diagnostics_enabled_);
 
-  uint16_t start_angle{ master_.getScanRange().getStart().value() };
-  uint16_t end_angle{ master_.getScanRange().getEnd().value() };
-  uint16_t resolution{ master_.getResolution().value() };
+  int16_t start_angle{ master_.getScanRange().getStart().value() };
+  int16_t end_angle{ master_.getScanRange().getEnd().value() };
+  int16_t resolution{ master_.getResolution().value() };
   raw_processing::write(os, start_angle);
   raw_processing::write(os, end_angle);
   raw_processing::write(os, resolution);
 
   for (const auto& slave : slaves_)
   {
-    uint16_t slave_start_angle{ slave.getScanRange().getStart().value() };
-    uint16_t slave_end_angle{ slave.getScanRange().getEnd().value() };
-    uint16_t slave_resolution{ slave.getResolution().value() };
+    int16_t slave_start_angle{ slave.getScanRange().getStart().value() };
+    int16_t slave_end_angle{ slave.getScanRange().getEnd().value() };
+    int16_t slave_resolution{ slave.getResolution().value() };
     raw_processing::write(os, slave_start_angle);
     raw_processing::write(os, slave_end_angle);
     raw_processing::write(os, slave_resolution);

--- a/test/unit_tests/unittest_scan_range.cpp
+++ b/test/unit_tests/unittest_scan_range.cpp
@@ -26,11 +26,11 @@ namespace psen_scan_v2_test
 static constexpr TenthOfDegree MIN_ALLOWED_ANGLE{ 7 };
 static constexpr TenthOfDegree MAX_ALLOWED_ANGLE{ 54 };
 
-static constexpr TenthOfDegree VALID_START_ANGLE{ MIN_ALLOWED_ANGLE.value() + 1u };
-static constexpr TenthOfDegree VALID_END_ANGLE{ MAX_ALLOWED_ANGLE.value() - 1u };
+static constexpr TenthOfDegree VALID_START_ANGLE{ MIN_ALLOWED_ANGLE.value() + 1 };
+static constexpr TenthOfDegree VALID_END_ANGLE{ MAX_ALLOWED_ANGLE.value() - 1 };
 
-static constexpr TenthOfDegree TOO_SMALL_SCAN_ANGLE{ MIN_ALLOWED_ANGLE.value() - 1u };
-static constexpr TenthOfDegree TOO_LARGE_SCAN_ANGLE{ MAX_ALLOWED_ANGLE.value() + 1u };
+static constexpr TenthOfDegree TOO_SMALL_SCAN_ANGLE{ MIN_ALLOWED_ANGLE.value() - 1 };
+static constexpr TenthOfDegree TOO_LARGE_SCAN_ANGLE{ MAX_ALLOWED_ANGLE.value() + 1 };
 
 using TestScanRange = ScanRange<MIN_ALLOWED_ANGLE.value(), MAX_ALLOWED_ANGLE.value()>;
 
@@ -61,7 +61,7 @@ TEST(ScanRangeTest, testEndAngleTooLarge)
 
 TEST(ScanRangeTest, testEndAngleSmallerThanStartAngle)
 {
-  EXPECT_THROW(TestScanRange(TenthOfDegree(17u), TenthOfDegree(15u)), std::invalid_argument);
+  EXPECT_THROW(TestScanRange(TenthOfDegree(17), TenthOfDegree(15)), std::invalid_argument);
 }
 
 }  // namespace psen_scan_v2_test

--- a/test/unit_tests/unittest_start_request.cpp
+++ b/test/unit_tests/unittest_start_request.cpp
@@ -100,7 +100,7 @@ TEST_F(StartRequestTest, constructorTest)
 
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::MASTER_START_ANGLE), scan_range.getStart().value()));
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::MASTER_END_ANGLE), scan_range.getEnd().value()));
-  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::MASTER_ANGLE_RESOLUTION), degreeToTenthDegree(0.2)));
+  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::MASTER_ANGLE_RESOLUTION), static_cast<int16_t>(2)));
 
   EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::SLAVE_ONE_START_ANGLE), 0));
   EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::SLAVE_ONE_END_ANGLE), 0));

--- a/test/unit_tests/unittest_tenth_degree_conversion.cpp
+++ b/test/unit_tests/unittest_tenth_degree_conversion.cpp
@@ -27,24 +27,24 @@ namespace psen_scan_v2_test
 {
 TEST(TenthDegreeConversionTests, testInTenthDegree)
 {
-  const uint16_t expected_tenth_degree{ 11 };
+  const int16_t expected_tenth_degree{ 11 };
   const double angle_in_rad{ (static_cast<double>(expected_tenth_degree) / 1800.) * boost::math::double_constants::pi };
   EXPECT_EQ(expected_tenth_degree, psen_scan_v2::radToTenthDegree(angle_in_rad));
 }
 
 TEST(TenthDegreeConversionTests, testOutOfRangeAngle)
 {
-  const double max_exceeding_angle_in_rad{ static_cast<double>(std::numeric_limits<uint16_t>::max()) + .1 };
+  const double max_exceeding_angle_in_rad{ static_cast<double>(std::numeric_limits<int16_t>::max()) + .1 };
   EXPECT_THROW(psen_scan_v2::radToTenthDegree(max_exceeding_angle_in_rad), std::invalid_argument);
 
-  const double min_exceeding_angle_in_rad{ static_cast<double>(std::numeric_limits<uint16_t>::min()) - .1 };
+  const double min_exceeding_angle_in_rad{ static_cast<double>(std::numeric_limits<int16_t>::min()) - .1 };
   EXPECT_THROW(psen_scan_v2::radToTenthDegree(min_exceeding_angle_in_rad), std::invalid_argument);
 }
 
 TEST(TenthDegreeConversionTests, testInRadian)
 {
   const double expected_radian{ 0.01 * boost::math::double_constants::pi };
-  const uint16_t angle_in_tenth_degree{ 18 };
+  const int16_t angle_in_tenth_degree{ 18 };
   EXPECT_DOUBLE_EQ(expected_radian, psen_scan_v2::tenthDegreeToRad(angle_in_tenth_degree));
 }
 

--- a/test/unit_tests/unittest_tenth_degree_conversion.cpp
+++ b/test/unit_tests/unittest_tenth_degree_conversion.cpp
@@ -25,14 +25,21 @@
 
 namespace psen_scan_v2_test
 {
-TEST(TenthDegreeConversionTests, testInTenthDegree)
+TEST(TenthDegreeConversionTests, radToTenthDegreeShouldReturnExpectedPositiveValue)
 {
   const int16_t expected_tenth_degree{ 11 };
   const double angle_in_rad{ (static_cast<double>(expected_tenth_degree) / 1800.) * boost::math::double_constants::pi };
   EXPECT_EQ(expected_tenth_degree, psen_scan_v2::radToTenthDegree(angle_in_rad));
 }
 
-TEST(TenthDegreeConversionTests, testOutOfRangeAngle)
+TEST(TenthDegreeConversionTests, radToTenthDegreeShouldReturnExpectedNegativeValue)
+{
+  const int16_t expected_tenth_degree{ -11 };
+  const double angle_in_rad{ (static_cast<double>(expected_tenth_degree) / 1800.) * boost::math::double_constants::pi };
+  EXPECT_EQ(expected_tenth_degree, psen_scan_v2::radToTenthDegree(angle_in_rad));
+}
+
+TEST(TenthDegreeConversionTests, radToTenthDegreeShouldThrowWhenAngleOutOfRange)
 {
   const double max_exceeding_angle_in_rad{ static_cast<double>(std::numeric_limits<int16_t>::max()) + .1 };
   EXPECT_THROW(psen_scan_v2::radToTenthDegree(max_exceeding_angle_in_rad), std::invalid_argument);
@@ -41,7 +48,7 @@ TEST(TenthDegreeConversionTests, testOutOfRangeAngle)
   EXPECT_THROW(psen_scan_v2::radToTenthDegree(min_exceeding_angle_in_rad), std::invalid_argument);
 }
 
-TEST(TenthDegreeConversionTests, testInRadian)
+TEST(TenthDegreeConversionTests, tenthDegreeToRadShouldReturnExpectedValue)
 {
   const double expected_radian{ 0.01 * boost::math::double_constants::pi };
   const int16_t angle_in_tenth_degree{ 18 };

--- a/test/unit_tests/unittest_tenth_of_degree.cpp
+++ b/test/unit_tests/unittest_tenth_of_degree.cpp
@@ -28,6 +28,12 @@ TEST(TenthOfDegreeTest, valueTest)
   EXPECT_EQ(tenth_of_degree.value(), 1);
 }
 
+TEST(TenthOfDegreeTest, negativeValueTest)
+{
+  TenthOfDegree tenth_of_degree{ -1 };
+  EXPECT_EQ(tenth_of_degree.value(), -1);
+}
+
 TEST(TenthOfDegreeTest, toRad)
 {
   TenthOfDegree tenth_of_degree{ 1 };


### PR DESCRIPTION
This essentially replaces `uint16_t` by `int16_t` such that the class `TenthOfDegree` and the angle conversions support negative values.

The protocol does not specify if the 16bit angles are signed or unsigned. But, concerning the scan range, it has to be in [0, 2750], such that it makes no difference if we use signed or unsigned type in (de)serialization.