### PR TITLE
Set start- and end-angle for acceptance test

### DIFF
--- a/test/hw_tests/hwtest_readme.md
+++ b/test/hw_tests/hwtest_readme.md
@@ -30,7 +30,7 @@ This step is only needed if the setup of the scanner or something within its env
 
 First startup the scanner
 ```
-roslaunch psen_scan_v2 psen_scan_v2.launch
+roslaunch psen_scan_v2 psen_scan_v2.launch angle_start:=-1.2 angle_end:=1.2
 ```
 
 After this record the bag file

--- a/test/hw_tests/hwtest_scan_compare.test
+++ b/test/hw_tests/hwtest_scan_compare.test
@@ -18,7 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <launch>
   <arg name="test_duration" default="10"/>
 
-  <include file="$(find psen_scan_v2)/launch/psen_scan_v2.launch" />
+  <include file="$(find psen_scan_v2)/launch/psen_scan_v2.launch">
+    <arg name="angle_start" value="-1.2" />
+    <arg name="angle_end" value="1.2" />
+  </include>
 
   <test test-name="scan_compare" pkg="psen_scan_v2" type="hwtest_scan_compare" time-limit="$(eval test_duration + 10)">
     <param name="testfile" value="$(env HW_TEST_SCAN_COMPARE_TESTFILE)"/>

--- a/test/hw_tests/hwtest_scan_compare.test
+++ b/test/hw_tests/hwtest_scan_compare.test
@@ -38,11 +38,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           negative: False
     </rosparam>
   </test>
-
-  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
-    <param name="topic" value="laser_scanner/scan" />
-    <param name="hz" value="$(eval 33.333 * 6)" /> <!--6 frame per round, 30ms per cycle-->
-    <param name="hzerror" value="0.5" />
-    <param name="test_duration" value="5.0" />
-  </test>
 </launch>

--- a/test/include/psen_scan_v2/laserscan_validator.h
+++ b/test/include/psen_scan_v2/laserscan_validator.h
@@ -92,16 +92,17 @@ public:
       {
         auto bin_expected = bins_expected_.find(bin_actual.first);
 
-        auto dist_actual = bin_actual.second;
-        auto dist_expected = bin_expected->second;
-
         if (bin_expected == bins_expected_.end())
         {
           check_result_.set_value(::testing::AssertionFailure() << "Did not find expected value for angle "
                                                                 << bin_actual.first / 10.
                                                                 << " in the given reference scan\n");
           check_done_ = true;
+          return;
         }
+
+        auto dist_actual = bin_actual.second;
+        auto dist_expected = bin_expected->second;
         auto distance = bhattacharyya_distance(dist_actual, dist_expected);
         if (distance > 10.)
         {


### PR DESCRIPTION
- Choose start- and end-angle such that environment is not expected to change
- remove `hztest` for now, since the publishing frequency varies with the scan range
- fix small bug in `laserscan_validator.h` which appeared through this change