### PR TITLE
Fix dep on rosbag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   rosfmt
-  rosbag
 )
 
 ## System dependencies are found with CMake's conventions
@@ -372,6 +371,8 @@ target_link_libraries(integrationtest_scanner_api
 
   # build this using catkin_make -DENABLE_HARDWARE_TESTING=ON
   if(ENABLE_HARDWARE_TESTING)
+    find_package(rosbag REQUIRED)
+
     add_rostest_gtest(hwtest_scan_compare
         test/hw_tests/hwtest_scan_compare.test
         test/hw_tests/hwtest_scan_compare.cpp


### PR DESCRIPTION
Since rosbag is only needed with the HW tests it should be defined as a dep only if `-DENABLE_HARDWARE_TESTING=ON` is set.

See http://build.ros.org/job/Mdev__psen_scan_v2__ubuntu_bionic_amd64/18/console

```
14:26:42 -- Could NOT find rosbag (missing: rosbag_DIR)
14:26:42 -- Could not find the required component 'rosbag'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
14:26:42 CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
14:26:42   Could not find a package configuration file provided by "rosbag" with any
14:26:42   of the following names:
14:26:42 
14:26:42     rosbagConfig.cmake
14:26:42     rosbag-config.cmake
14:26:42 
14:26:42   Add the installation prefix of "rosbag" to CMAKE_PREFIX_PATH or set
14:26:42   "rosbag_DIR" to a directory containing one of the above files.  If "rosbag"
14:26:42   provides a separate development package or SDK, be sure it has been
14:26:42   installed.
14:26:42 Call Stack (most recent call first):
14:26:42   CMakeLists.txt:25 (find_package)
```