### PR TITLE
Fix friend declaration

### DIFF
--- a/include/psen_scan_v2/diagnostics.h
+++ b/include/psen_scan_v2/diagnostics.h
@@ -147,7 +147,7 @@ public:
   constexpr Message(const ScannerId& id, const diagnostic::ErrorLocation& location);
   constexpr bool operator==(const diagnostic::Message& rhs) const;
 
-  friend diagnostic::raw_message::Field diagnostic::serialize(const std::vector<diagnostic::Message>& messages);
+  friend raw_message::Field serialize(const std::vector<diagnostic::Message>& messages);
 
   constexpr ScannerId getScannerId() const
   {

--- a/include/psen_scan_v2/monitoring_frame_msg.h
+++ b/include/psen_scan_v2/monitoring_frame_msg.h
@@ -91,8 +91,7 @@ private:
 
 public:
   friend DynamicSizeRawData serialize(const monitoring_frame::Message& frame);
-  friend monitoring_frame::Message psen_scan_v2::monitoring_frame::deserialize(const MaxSizeRawData& data,
-                                                                               const std::size_t& num_bytes);
+  friend monitoring_frame::Message deserialize(const MaxSizeRawData& data, const std::size_t& num_bytes);
 };
 
 }  // namespace monitoring_frame


### PR DESCRIPTION
Tbh I am not sure why this is not detected earlier but it shows up if you run against noetic using
```
rosrun industrial_ci run_ci ROS_DISTRO="noetic" UPSTREAM_WORKSPACE='github:PilzDE/pilz_robots#fix/missing_test_dep_pilz_utils -pilz_robots/pilz_control -pilz_robots/prbt_hardware_support -pilz_robots/pilz_status_indicator_rqt -pilz_robots/prbt_moveit_config -pilz_robots/prbt_support -pilz_robots/pilz_robots -pilz_robots/prbt_gazebo -pilz_robots/prbt_ikfast_manipulator_plugin'
```

Errors are
```
In file included from /root/target_ws/src/psen_scan_v2/src/diagnostics.cpp:18:
/root/target_ws/src/psen_scan_v2/include/psen_scan_v2/diagnostics.h:150:111: error: ‘psen_scan_v2::monitoring_frame::diagnostic::raw_message::Field psen_scan_v2::monitoring_frame::diagnostic::serialize(const std::vector<psen_scan_v2::monitoring_frame::diagnostic::Message>&)’ should have been declared inside ‘psen_scan_v2::monitoring_frame::diagnostic’
  150 |   friend diagnostic::raw_message::Field diagnostic::serialize(const std::vector<diagnostic::Message>& messages);
```
and
```
In file included from /root/target_ws/src/psen_scan_v2/include/psen_scan_v2/monitoring_frame_deserialization.h:22,
                 from /root/target_ws/src/psen_scan_v2/src/monitoring_frame_deserialization.cpp:22:
/root/target_ws/src/psen_scan_v2/include/psen_scan_v2/monitoring_frame_msg.h:95:108: error: ‘psen_scan_v2::monitoring_frame::Message psen_scan_v2::monitoring_frame::deserialize(const MaxSizeRawData&, const size_t&)’ should have been declared inside ‘psen_scan_v2::monitoring_frame’
   95 |                                                                                const std::size_t& num_bytes);
```