### PR TITLE
Adapt to new logger API

### DIFF
--- a/test/integration_tests/integrationtest_scanner_api.cpp
+++ b/test/integration_tests/integrationtest_scanner_api.cpp
@@ -532,7 +532,7 @@ TEST_F(ScannerAPITests, shouldNotCallLaserscanCallbackInCaseOfEmptyMonitoringFra
 
   Barrier empty_msg_received;
   // Needed to allow all other log messages which might be received
-  EXPECT_CALL(*ros_log_mock, append(::testing::_, ::testing::_)).Times(AnyNumber());
+  EXPECT_CALL(*ros_log_mock, internal_append(::testing::_, ::testing::_)).Times(AnyNumber());
   EXPECT_LOG(*ros_log_mock, WARN, "No transition in state 2 for event MonitoringFrameReceivedError.")
       .Times(1)
       .WillOnce(OpenBarrier(&empty_msg_received));
@@ -584,7 +584,7 @@ TEST_F(ScannerAPITests, shouldShowUserMsgIfMonitoringFramesAreMissing)
 
   Barrier user_msg_barrier;
   // Needed to allow all other log messages which might be received
-  EXPECT_CALL(*ros_log_mock, append(::testing::_, ::testing::_)).Times(AnyNumber());
+  EXPECT_CALL(*ros_log_mock, internal_append(::testing::_, ::testing::_)).Times(AnyNumber());
   EXPECT_LOG(*ros_log_mock,
              WARN,
              "Detected dropped MonitoringFrame."
@@ -637,7 +637,7 @@ TEST_F(ScannerAPITests, shouldShowUserMsgIfTooManyMonitoringFramesAreReceived)
 
   Barrier user_msg_barrier;
   // Needed to allow all other log messages which might be received
-  EXPECT_CALL(*ros_log_mock, append(::testing::_, ::testing::_)).Times(AnyNumber());
+  EXPECT_CALL(*ros_log_mock, internal_append(::testing::_, ::testing::_)).Times(AnyNumber());
   EXPECT_LOG(*ros_log_mock, WARN, "Unexpected: Too many MonitoringFrames for one scan round received.")
       .Times(1)
       .WillOnce(OpenBarrier(&user_msg_barrier));
@@ -671,7 +671,7 @@ TEST_F(ScannerAPITests, shouldShowUserMsgIfMonitoringFrameReceiveTimeout)
 
   Barrier user_msg_barrier;
   // Needed to allow all other log messages which might be received
-  EXPECT_CALL(*ros_log_mock, append(::testing::_, ::testing::_)).Times(AnyNumber());
+  EXPECT_CALL(*ros_log_mock, internal_append(::testing::_, ::testing::_)).Times(AnyNumber());
   EXPECT_LOG(*ros_log_mock,
              WARN,
              "Timeout while waiting for MonitoringFrame message."


### PR DESCRIPTION
This is caused by https://github.com/PilzDE/pilz_robots/commit/e9a0b37f7104f645e3cba6f2636bfb375d6d7e37 but was possibly not detected due to using the system installed headers which is fixed in https://github.com/PilzDE/pilz_robots/pull/466

A double release of pilz_robots and psen_scan_v2 is required to fix the situation.

