### PR TITLE
Move Scanner port to ScannerConfiguration

### DIFF
--- a/include/psen_scan_v2/default_parameters.h
+++ b/include/psen_scan_v2/default_parameters.h
@@ -22,6 +22,9 @@ namespace psen_scan_v2
 {
 namespace constants
 {
+static constexpr unsigned short DATA_PORT_OF_SCANNER_DEVICE{ 2000 };
+static constexpr unsigned short CONTROL_PORT_OF_SCANNER_DEVICE{ 3000 };
+
 //! @brief Start angle of measurement.
 static constexpr double DEFAULT_ANGLE_START(-degreeToRadian(137.5));
 //! @brief  End angle of measurement.

--- a/include/psen_scan_v2/scan_range.h
+++ b/include/psen_scan_v2/scan_range.h
@@ -47,15 +47,15 @@ public:
 private:
   TenthOfDegree start_angle_{ 0 };
   TenthOfDegree end_angle_{ 0 };
-
-  const TenthOfDegree MIN_ANGLE{ min_allowed_angle };
-  const TenthOfDegree MAX_ANGLE{ max_allowed_angle };
 };
 
 template <int16_t min_angle, int16_t max_angle>
 constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_angle, const TenthOfDegree& end_angle)
   : start_angle_(start_angle), end_angle_(end_angle)
 {
+  const TenthOfDegree MIN_ANGLE{ min_angle };
+  const TenthOfDegree MAX_ANGLE{ max_angle };
+
   if (start_angle < MIN_ANGLE || start_angle > MAX_ANGLE)
   {
     throw std::out_of_range("Start angle out of range");

--- a/include/psen_scan_v2/scanner_config_builder.h
+++ b/include/psen_scan_v2/scanner_config_builder.h
@@ -1,0 +1,121 @@
+#ifndef PSEN_SCAN_V2_SCANNER_CONFIG_BUILDER_H
+#define PSEN_SCAN_V2_SCANNER_CONFIG_BUILDER_H
+
+#include <cmath>
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <limits>
+
+#include <arpa/inet.h>
+
+#include "psen_scan_v2/scanner_configuration.h"
+#include "psen_scan_v2/scan_range.h"
+#include "psen_scan_v2/angle_conversions.h"
+
+namespace psen_scan_v2
+{
+class ScannerConfigurationBuilder
+{
+public:
+  ScannerConfiguration build() const;
+
+public:
+  ScannerConfigurationBuilder& hostIP(const std::string&);
+  ScannerConfigurationBuilder& hostDataPort(const int&);
+  ScannerConfigurationBuilder& hostControlPort(const int&);
+  ScannerConfigurationBuilder& scannerIp(const std::string&);
+  ScannerConfigurationBuilder& scannerDataPort(const int&);
+  ScannerConfigurationBuilder& scannerControlPort(const int&);
+  ScannerConfigurationBuilder& scanRange(const DefaultScanRange&);
+  ScannerConfigurationBuilder& enableDiagnostics();
+
+private:
+  static uint16_t convertPort(const int& port);
+  static uint32_t convertIP(const std::string& ip);
+
+private:
+  ScannerConfiguration config_;
+};
+
+inline ScannerConfiguration ScannerConfigurationBuilder::build() const
+{
+  if (!config_.isValid())
+  {
+    throw std::runtime_error("Scanner configuration not complete");
+  }
+  return config_;
+}
+
+uint32_t ScannerConfigurationBuilder::convertIP(const std::string& ip)
+{
+  const auto ip_number = inet_network(ip.c_str());
+  if (static_cast<in_addr_t>(-1) == ip_number)
+  {
+    throw std::invalid_argument("IP invalid");
+  }
+  assert(sizeof(ip_number) == 4 && "ip_number has not the expected size");
+  return static_cast<uint32_t>(ip_number);
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::hostIP(const std::string& ip)
+{
+  config_.host_ip_ = convertIP(ip);
+
+  return *this;
+}
+
+inline uint16_t ScannerConfigurationBuilder::convertPort(const int& port)
+{
+  if (port < std::numeric_limits<uint16_t>::min() || port > std::numeric_limits<uint16_t>::max())
+  {
+    throw std::out_of_range("Port out of range");
+  }
+  return htole16(static_cast<uint16_t>(port));
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::hostDataPort(const int& port)
+{
+  config_.host_data_port_ = convertPort(port);
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::hostControlPort(const int& port)
+{
+  config_.host_control_port_ = convertPort(port);
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scannerIp(const std::string& ip)
+{
+  config_.scanner_ip_ = convertIP(ip);
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scannerDataPort(const int& port)
+{
+  config_.scanner_data_port_ = convertPort(port);
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scannerControlPort(const int& port)
+{
+  config_.scanner_control_port_ = convertPort(port);
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanRange(const DefaultScanRange& scan_range)
+{
+  config_.scan_range_ = scan_range;
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableDiagnostics()
+{
+  config_.diagnostics_enabled_ = true;
+  return *this;
+}
+
+}  // namespace psen_scan_v2
+
+#endif  // PSEN_SCAN_V2_SCANNER_CONFIG_BUILDER_H

--- a/include/psen_scan_v2/scanner_config_builder.h
+++ b/include/psen_scan_v2/scanner_config_builder.h
@@ -1,3 +1,18 @@
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #ifndef PSEN_SCAN_V2_SCANNER_CONFIG_BUILDER_H
 #define PSEN_SCAN_V2_SCANNER_CONFIG_BUILDER_H
 

--- a/include/psen_scan_v2/scanner_configuration.h
+++ b/include/psen_scan_v2/scanner_configuration.h
@@ -15,9 +15,7 @@
 #ifndef PSEN_SCAN_V2_SCANNER_CONFIGURATION_H
 #define PSEN_SCAN_V2_SCANNER_CONFIGURATION_H
 
-#include <string>
-
-#include <arpa/inet.h>
+#include <boost/optional.hpp>
 
 #include "psen_scan_v2/scan_range.h"
 
@@ -29,44 +27,38 @@ namespace psen_scan_v2
  */
 class ScannerConfiguration
 {
-public:
-  /**
-   * @brief Construtor.
-   *
-   * @param host_ip IP address of the host.
-   * @param host_udp_port_data Port on which monitoring frames (scans) should be received.
-   * @param host_udp_port_control Port used to send commands (start/stop) and receive the corresponding replies.
-   * @param device_ip IP address of the scanner.
-   * @param scan_range Range in which measurements are taken.
-   * @param diagnostics_enabled Request diagnostic data from the scanner?
-   */
-  ScannerConfiguration(const std::string& host_ip,
-                       const int& host_udp_port_data,
-                       const int& host_udp_port_control,
-                       const std::string& device_ip,
-                       const DefaultScanRange& scan_range,
-                       const bool diagnostics_enabled);
+private:
+  ScannerConfiguration() = default;
 
 public:
   uint32_t hostIp() const;
-
   uint16_t hostUDPPortData() const;
   uint16_t hostUDPPortControl() const;
 
   uint32_t clientIp() const;
+  uint16_t scannerDataPort() const;
+  uint16_t scannerControlPort() const;
 
   const DefaultScanRange& scanRange() const;
 
   bool diagnosticsEnabled() const;
 
 private:
-  uint32_t host_ip_;
-  uint16_t host_udp_port_data_;
-  uint16_t host_udp_port_control_;
+  friend class ScannerConfigurationBuilder;
 
-  uint32_t client_ip_;
+private:
+  bool isValid() const;
 
-  const DefaultScanRange scan_range_;
+private:
+  boost::optional<uint32_t> host_ip_;
+  boost::optional<uint16_t> host_data_port_;
+  boost::optional<uint16_t> host_control_port_;
+
+  boost::optional<uint32_t> scanner_ip_;
+  boost::optional<uint16_t> scanner_data_port_;
+  boost::optional<uint16_t> scanner_control_port_;
+
+  boost::optional<DefaultScanRange> scan_range_{};
   bool diagnostics_enabled_{ false };
 };
 

--- a/include/psen_scan_v2/scanner_v2.h
+++ b/include/psen_scan_v2/scanner_v2.h
@@ -39,17 +39,10 @@ using namespace psen_scan_v2::scanner_protocol;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-// TODO: Move to ScannerController class and read from ScannerConfiguration
-static constexpr unsigned short DATA_PORT_OF_SCANNER_DEVICE{ 2000 };
-static constexpr unsigned short CONTROL_PORT_OF_SCANNER_DEVICE{ 3000 };
-
 class ScannerV2 : public IScanner
 {
 public:
-  ScannerV2(const ScannerConfiguration& scanner_config,
-            const LaserScanCallback& laser_scan_cb,
-            const unsigned short data_port_scanner = DATA_PORT_OF_SCANNER_DEVICE,
-            const unsigned short control_port_scanner = CONTROL_PORT_OF_SCANNER_DEVICE);
+  ScannerV2(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_cb);
   ~ScannerV2();
 
 public:
@@ -59,8 +52,7 @@ public:
 private:
   // Raw pointer used here because "msm::back::state_machine" cannot properly pass
   // a "std::unique_ptr" to "msm::front::state_machine_def".
-  StateMachineArgs* createStateMachineArgs(const unsigned short& data_port_scanner,
-                                           const unsigned short& control_port_scanner);
+  StateMachineArgs* createStateMachineArgs();
 
   template <class T>
   void triggerEventWithParam(const T& event);

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -25,6 +25,7 @@
 #include "psen_scan_v2/ros_scanner_node.h"
 #include "psen_scan_v2/default_parameters.h"
 #include "psen_scan_v2/scanner_configuration.h"
+#include "psen_scan_v2/scanner_config_builder.h"
 #include "psen_scan_v2/scan_range.h"
 
 #include <rosconsole_bridge/bridge.h>
@@ -75,12 +76,17 @@ int main(int argc, char** argv)
                              getOptionalParamFromServer<double>(pnh, PARAM_ANGLE_END, DEFAULT_ANGLE_END))
     };
 
-    ScannerConfiguration scanner_configuration(getRequiredParamFromServer<std::string>(pnh, PARAM_HOST_IP),
-                                               getRequiredParamFromServer<int>(pnh, PARAM_HOST_DATA_PORT),
-                                               getRequiredParamFromServer<int>(pnh, PARAM_HOST_CONTROL_PORT),
-                                               getRequiredParamFromServer<std::string>(pnh, PARAM_SCANNER_IP),
-                                               scan_range,
-                                               true);
+    ScannerConfigurationBuilder config_builder;
+    config_builder.hostIP(getRequiredParamFromServer<std::string>(pnh, PARAM_HOST_IP))
+        .hostDataPort(getRequiredParamFromServer<int>(pnh, PARAM_HOST_DATA_PORT))
+        .hostControlPort(getRequiredParamFromServer<int>(pnh, PARAM_HOST_CONTROL_PORT))
+        .scannerIp(getRequiredParamFromServer<std::string>(pnh, PARAM_SCANNER_IP))
+        .scannerDataPort(DATA_PORT_OF_SCANNER_DEVICE)
+        .scannerControlPort(CONTROL_PORT_OF_SCANNER_DEVICE)
+        .scanRange(scan_range)
+        .enableDiagnostics();
+
+    ScannerConfiguration scanner_configuration{ config_builder.build() };
 
     ROSScannerNode ros_scanner_node(pnh,
                                     DEFAULT_PUBLISH_TOPIC,

--- a/src/scanner_configuration.cpp
+++ b/src/scanner_configuration.cpp
@@ -13,80 +13,52 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <cmath>
-#include <cassert>
-#include <stdexcept>
-#include <limits>
-
-#include <arpa/inet.h>
-
-#include "psen_scan_v2/angle_conversions.h"
 #include "psen_scan_v2/scanner_configuration.h"
 
 namespace psen_scan_v2
 {
-ScannerConfiguration::ScannerConfiguration(const std::string& host_ip,
-                                           const int& host_udp_port_data,
-                                           const int& host_udp_port_control,
-                                           const std::string& client_ip,
-                                           const DefaultScanRange& scan_range,
-                                           const bool diagnostics_enabled)
-  : scan_range_(scan_range), diagnostics_enabled_(diagnostics_enabled)
+bool ScannerConfiguration::isValid() const
 {
-  const auto host_ip_number = inet_network(host_ip.c_str());
-  if (static_cast<in_addr_t>(-1) == host_ip_number)
-  {
-    throw std::invalid_argument("Host IP invalid");
-  }
-  assert(sizeof(host_ip_number) == 4 && "host_ip_number has not the expected size");
-  host_ip_ = static_cast<uint32_t>(host_ip_number);
-
-  if (host_udp_port_data < std::numeric_limits<uint16_t>::min() ||
-      host_udp_port_data > std::numeric_limits<uint16_t>::max())
-  {
-    throw std::out_of_range("Host UDP port out of range");
-  }
-  host_udp_port_data_ = htole16(static_cast<uint16_t>(host_udp_port_data));
-
-  if (host_udp_port_control < std::numeric_limits<uint16_t>::min() ||
-      host_udp_port_control > std::numeric_limits<uint16_t>::max())
-  {
-    throw std::out_of_range("Host UDP port out of range");
-  }
-  host_udp_port_control_ = htole16(static_cast<uint16_t>(host_udp_port_control));
-
-  const auto client_ip_number = inet_network(client_ip.c_str());
-  if (static_cast<in_addr_t>(-1) == client_ip_number)
-  {
-    throw std::invalid_argument("client IP invalid");
-  }
-  assert(sizeof(client_ip_number) == 4 && "client_ip_number has not the expected size");
-  client_ip_ = static_cast<uint32_t>(client_ip_number);
+  // clang-format off
+  return host_ip_     && host_data_port_    && host_control_port_ &&
+         scanner_ip_  && scanner_data_port_ && scanner_control_port_ &&
+         scan_range_;
+  // clang-format on
 }
 
 uint32_t ScannerConfiguration::hostIp() const
 {
-  return host_ip_;
+  return *host_ip_;
 }
 
 uint16_t ScannerConfiguration::hostUDPPortData() const
 {
-  return host_udp_port_data_;
+  return *host_data_port_;
 }
 
 uint16_t ScannerConfiguration::hostUDPPortControl() const
 {
-  return host_udp_port_control_;
+  return *host_control_port_;
 }
 
 uint32_t ScannerConfiguration::clientIp() const
 {
-  return client_ip_;
+  return *scanner_ip_;
+}
+
+uint16_t ScannerConfiguration::scannerDataPort() const
+{
+  return *scanner_data_port_;
+}
+
+uint16_t ScannerConfiguration::scannerControlPort() const
+{
+  return *scanner_control_port_;
 }
 
 const DefaultScanRange& ScannerConfiguration::scanRange() const
 {
-  return scan_range_;
+  return *scan_range_;
 }
 
 bool ScannerConfiguration::diagnosticsEnabled() const

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -31,6 +31,7 @@
 #include "psen_scan_v2/laserscan.h"
 #include "psen_scan_v2/scanner_mock.h"
 #include "psen_scan_v2/scanner_configuration.h"
+#include "psen_scan_v2/scanner_config_builder.h"
 #include "psen_scan_v2/default_parameters.h"
 #include "psen_scan_v2/scan_range.h"
 #include "psen_scan_v2/laserscan_ros_conversions.h"
@@ -93,15 +94,25 @@ static constexpr DefaultScanRange SCAN_RANGE{ TenthOfDegree(0), TenthOfDegree(27
 static constexpr int SCANNER_STARTED_TIMEOUT_MS{ 3000 };
 static constexpr int SCANNER_STOPPED_TIMEOUT_MS{ 3000 };
 static constexpr int LASERSCAN_RECEIVED_TIMEOUT{ 3000 };
-static constexpr bool DIAGNOSTICS_ENABLED{ false };
+
+static ScannerConfiguration createValidConfig()
+{
+  return ScannerConfigurationBuilder()
+      .hostIP(HOST_IP)
+      .hostDataPort(HOST_UDP_PORT_DATA)
+      .hostControlPort(HOST_UDP_PORT_CONTROL)
+      .scannerIp(DEVICE_IP)
+      .scannerDataPort(DATA_PORT_OF_SCANNER_DEVICE)
+      .scannerControlPort(CONTROL_PORT_OF_SCANNER_DEVICE)
+      .scanRange(SCAN_RANGE)
+      .build();
+}
 
 class RosScannerNodeTests : public testing::Test, public testing::AsyncTest
 {
 protected:
-  RosScannerNodeTests()
-    : scanner_config_(HOST_IP, HOST_UDP_PORT_DATA, HOST_UDP_PORT_CONTROL, DEVICE_IP, SCAN_RANGE, DIAGNOSTICS_ENABLED){};
   ros::NodeHandle nh_priv_{ "~" };
-  ScannerConfiguration scanner_config_;
+  ScannerConfiguration scanner_config_{ createValidConfig() };
 };
 
 TEST_F(RosScannerNodeTests, testScannerInvocation)


### PR DESCRIPTION
This PR moves the scanner ports to the `ScannerConfiguration` class. Because the number of  parameters of the `ScannerConfiguration` reached a critical "mass", the `ScannerConfigurationBuilder` is introduced.