### PR TITLE
Make invalid ScanRange creation explicit

### DIFF
--- a/include/psen_scan_v2/scan_range.h
+++ b/include/psen_scan_v2/scan_range.h
@@ -31,8 +31,6 @@ class ScanRange
   static_assert(min_allowed_angle < max_allowed_angle, "MIN-angle limit smaller than MAX-angle limit.");
 
 public:
-  ScanRange() = default;
-
   /**
    * @brief Constructor.
    *
@@ -43,6 +41,12 @@ public:
 
   const TenthOfDegree& getStart() const;
   const TenthOfDegree& getEnd() const;
+
+public:
+  static constexpr ScanRange<min_allowed_angle, max_allowed_angle> createInvalidScanRange();
+
+private:
+  ScanRange() = default;
 
 private:
   TenthOfDegree start_angle_{ 0 };
@@ -70,6 +74,12 @@ constexpr ScanRange<min_angle, max_angle>::ScanRange(const TenthOfDegree& start_
   {
     throw std::invalid_argument("Start angle must be smaller or equal to end angle");
   }
+}
+
+template <int16_t min_angle, int16_t max_angle>
+constexpr ScanRange<min_angle, max_angle> ScanRange<min_angle, max_angle>::createInvalidScanRange()
+{
+  return ScanRange<min_angle, max_angle>();
 }
 
 template <int16_t min_angle, int16_t max_angle>

--- a/include/psen_scan_v2/start_request.h
+++ b/include/psen_scan_v2/start_request.h
@@ -62,7 +62,7 @@ private:
     constexpr TenthOfDegree getResolution() const;
 
   private:
-    const DefaultScanRange scan_range_{};
+    const DefaultScanRange scan_range_{ DefaultScanRange::createInvalidScanRange() };
     const TenthOfDegree resolution_{ 0 };
   };
 


### PR DESCRIPTION
This PR improves the code readability by removing implicit creation of invalid `ScanRange` objects.