### PR TITLE
Remove exports on dependent packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ find_package(fmt REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS
-    roscpp sensor_msgs
+    roscpp
+    sensor_msgs
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,10 @@ find_package(Boost REQUIRED COMPONENTS system)
 find_package(console_bridge REQUIRED)
 find_package(fmt REQUIRED)
 
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS
+    roscpp sensor_msgs
+)
 
 
 ###############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 find_package(console_bridge REQUIRED)
 find_package(fmt REQUIRED)
 
-catkin_package(
-  CATKIN_DEPENDS
-    rosconsole_bridge
-    roscpp
-    sensor_msgs
-  DEPENDS
-    console_bridge
-)
+catkin_package()
 
 
 ###############


### PR DESCRIPTION
Some of the dependent packages/libraries do not need to be passed along since we do not export our header files.