### PR TITLE
Move #include out of namespace scope

### DIFF
--- a/include/psen_scan_v2/scanner_state_machine.h
+++ b/include/psen_scan_v2/scanner_state_machine.h
@@ -208,12 +208,12 @@ private:
   monitoring_frame::ScanValidator complete_scan_validator_;
 };
 
-#include "psen_scan_v2/scanner_state_machine_def.h"
-
 // Pick a back-end
 using ScannerStateMachine = msm::back::state_machine<ScannerProtocolDef>;
 
 }  // namespace scanner_protocol
 }  // namespace psen_scan_v2
+
+#include "psen_scan_v2/scanner_state_machine_def.h"
 
 #endif  // PSEN_SCAN_V2_SCANNER_PROTOCOL_DEF_H

--- a/include/psen_scan_v2/scanner_state_machine_def.h
+++ b/include/psen_scan_v2/scanner_state_machine_def.h
@@ -13,6 +13,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+namespace psen_scan_v2
+{
+namespace scanner_protocol
+{
 inline ScannerProtocolDef::ScannerProtocolDef(StateMachineArgs* const args) : args_(args)
 {
 }
@@ -193,3 +197,6 @@ void ScannerProtocolDef::no_transition(const scanner_events::RawMonitoringFrameR
 {
   PSENSCAN_WARN("StateMachine", "Received monitoring frame despite not waiting for it");
 }
+
+}  // namespace scanner_protocol
+}  // namespace psen_scan_v2


### PR DESCRIPTION
## Description

These changes partly fix the doxygen documentation.

Before, doxygen could not find the file `scanner_state_machine_def.h`.
With this change the file is included in the docu. Now there are other warnings, because it contains macros which not being expanded by doxygen.
