### PR TITLE
Increases cmake minimum required version to remove warnings for noeti…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 project(psen_scan_v2)
 
 add_compile_options(-std=c++14)


### PR DESCRIPTION
## Description

These changes remove the build warnings you get on noetic builds
 E.G. see https://varhowto.com/ros-noetic/

Warning you get prior to this version.
```
--- stderr: psen_scan_v2                                                    
CMake Warning (dev) at CMakeLists.txt:17 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```