### PR TITLE
Make specifying ports optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package psen_scan_v2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Make specifying udp ports optional
+* Contributors: Pilz GmbH and Co. KG
+
+
 0.1.3 (2020-12-09)
 ------------------
 * Add ROS noetic support (`#103 <https://github.com/PilzDE/psen_scan_v2/issues/103>`_)

--- a/README.md
+++ b/README.md
@@ -72,14 +72,16 @@ Publishes a complete scan from the PSENscan safety laser scanner.
 _host_ip_ (_string_, default: "192.168.0.50")<br/>
 IP-Address of host machine.
 
+_sensor_ip_ (_string_, default: "192.168.0.10")<br/>
+IP-Address of safety laser scanner.
+
+### Further Parameters (optional)
+
 _host_udp_port_data_ (_int_, default: 55115)<br/>
 UDP Port on which monitoring frames (scans) should be received.
 
 _host_udp_port_control_ (_int_, default: 55116)<br/>
 UDP Port used to send commands (start/stop) and receive the corresponding replies.
-
-_sensor_ip_ (_string_, default: "192.168.0.10")<br/>
-IP-Address of safety laser scanner.
 
 _prefix_ (_string_, default: "laser_1")<br/>
 Name of this scanner that can be changed to differentiate between multiple units.

--- a/include/psen_scan_v2/default_parameters.h
+++ b/include/psen_scan_v2/default_parameters.h
@@ -28,6 +28,9 @@ namespace constants
 static constexpr unsigned short DATA_PORT_OF_SCANNER_DEVICE{ 2000 };
 static constexpr unsigned short CONTROL_PORT_OF_SCANNER_DEVICE{ 3000 };
 
+static constexpr unsigned short DATA_PORT_OF_HOST_DEVICE{ 55115 };
+static constexpr unsigned short CONTROL_PORT_OF_HOST_DEVICE{ 55116 };
+
 //! @brief Start angle of measurement.
 static constexpr double DEFAULT_ANGLE_START(-degreeToRadian(137.5));
 //! @brief  End angle of measurement.

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -78,8 +78,8 @@ int main(int argc, char** argv)
 
     ScannerConfigurationBuilder config_builder;
     config_builder.hostIP(getRequiredParamFromServer<std::string>(pnh, PARAM_HOST_IP))
-        .hostDataPort(getRequiredParamFromServer<int>(pnh, PARAM_HOST_DATA_PORT))
-        .hostControlPort(getRequiredParamFromServer<int>(pnh, PARAM_HOST_CONTROL_PORT))
+        .hostDataPort(getOptionalParamFromServer<int>(pnh, PARAM_HOST_DATA_PORT, DATA_PORT_OF_HOST_DEVICE))
+        .hostControlPort(getOptionalParamFromServer<int>(pnh, PARAM_HOST_CONTROL_PORT, CONTROL_PORT_OF_HOST_DEVICE))
         .scannerIp(getRequiredParamFromServer<std::string>(pnh, PARAM_SCANNER_IP))
         .scannerDataPort(DATA_PORT_OF_SCANNER_DEVICE)
         .scannerControlPort(CONTROL_PORT_OF_SCANNER_DEVICE)


### PR DESCRIPTION
## Description

These changes allow the user to start the psen_scan driver without specifying the udp ports.

### Things to add, update or check by the maintainers before this PR can be merged.

* [x] Public api function documentation -> no changes
* [x] [Tutorials](https://wiki.ros.org/psen_scan_v2/Tutorials/ConfiguringPsenScanParametersWithYaml) Update "Required Parameters" section
* [x] Package Readme -> list of parameters does not change
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [x] CHANGELOG.rst updated

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [x] Which dependent packages do have to be released simultaneously? -> none
