### PR TITLE
Exclude line which can not be reached deterministically

### DIFF
--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -120,7 +120,7 @@ void ROSScannerNodeT<S>::run()
   scanner_.start();
   while (ros::ok() && !terminate_)
   {
-    r.sleep();
+    r.sleep();  // LCOV_EXCL_LINE can not be reached deterministically
   }
   const auto stop_future = scanner_.stop();
   const auto stop_status = stop_future.wait_for(3s);


### PR DESCRIPTION
## Description

These changes Fix #124

In a test we can not wait deterministically for the execution of the body of the while-loop before we terminate the node.

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))

### Review Checklist
* [ ] Code (coding rules, style guide)
