### PR TITLE
Enable setting log level in console bridge

### DIFF
--- a/include/psen_scan_v2/logging.h
+++ b/include/psen_scan_v2/logging.h
@@ -26,7 +26,7 @@
 #define PSENSCAN_LOG(name, file, line, level, ...)                                                                     \
   do                                                                                                                   \
   {                                                                                                                    \
-    console_bridge::getOutputHandler()->log(fmt::format("{}: {}", name, fmt::format(__VA_ARGS__)), level, file, line); \
+    console_bridge::log(file, line, level, fmt::format("{}: {}", name, fmt::format(__VA_ARGS__)).c_str());             \
   } while (false)  // https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block
 
 #define PSENSCAN_LOG_THROTTLE(period, name, file, line, level, ...)                                                    \

--- a/test/integration_tests/integrationtest_scanner_api.cpp
+++ b/test/integration_tests/integrationtest_scanner_api.cpp
@@ -257,6 +257,7 @@ protected:
 void ScannerAPITests::SetUp()
 {
   port_holder_.printPorts();
+  setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
 }
 
 void ScannerMock::startListeningForControlMsg()

--- a/test/unit_tests/unittest_logging.cpp
+++ b/test/unit_tests/unittest_logging.cpp
@@ -26,6 +26,7 @@ using namespace psen_scan_v2_test;
 TEST(LoggingTest, logInfo)
 {
   INJECT_LOG_MOCK;
+  setLogLevel(CONSOLE_BRIDGE_LOG_INFO);
   EXPECT_LOG(INFO, "Name: msg", __FILE__, __LINE__ + 1).Times(1);
   PSENSCAN_INFO("Name", "msg");
 }
@@ -33,6 +34,7 @@ TEST(LoggingTest, logInfo)
 TEST(LoggingTest, logDebug)
 {
   INJECT_LOG_MOCK;
+  setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
   EXPECT_LOG(DEBUG, "Name: msg", __FILE__, __LINE__ + 1).Times(1);
   PSENSCAN_DEBUG("Name", "msg");
 }
@@ -54,6 +56,7 @@ TEST(LoggingTest, logError)
 TEST(LoggingTest, logInfoThrottle)
 {
   INJECT_LOG_MOCK;
+  setLogLevel(CONSOLE_BRIDGE_LOG_INFO);
   EXPECT_LOG(INFO, "Name: msg", __FILE__, __LINE__ + 1).Times(1);
   PSENSCAN_INFO_THROTTLE(0.1, "Name", "msg");
 }
@@ -61,6 +64,7 @@ TEST(LoggingTest, logInfoThrottle)
 TEST(LoggingTest, logDebugThrottle)
 {
   INJECT_LOG_MOCK;
+  setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
   EXPECT_LOG(DEBUG, "Name: msg", __FILE__, __LINE__ + 1).Times(1);
   PSENSCAN_DEBUG_THROTTLE(0.1, "Name", "msg");
 }


### PR DESCRIPTION
## Description

These changes allow the user to set a log level via `console_bridge::setLogLevel()`.

Needed for #107
