### PR TITLE
Use defaults ports in ScannerConfiguration

### DIFF
--- a/include/psen_scan_v2/scanner_configuration.h
+++ b/include/psen_scan_v2/scanner_configuration.h
@@ -17,6 +17,7 @@
 
 #include <boost/optional.hpp>
 
+#include "psen_scan_v2/default_parameters.h"
 #include "psen_scan_v2/scan_range.h"
 
 namespace psen_scan_v2
@@ -51,12 +52,12 @@ private:
 
 private:
   boost::optional<uint32_t> host_ip_;
-  boost::optional<uint16_t> host_data_port_;
-  boost::optional<uint16_t> host_control_port_;
+  uint16_t host_data_port_{ constants::DATA_PORT_OF_HOST_DEVICE };
+  uint16_t host_control_port_{ constants::CONTROL_PORT_OF_HOST_DEVICE };
 
   boost::optional<uint32_t> scanner_ip_;
-  boost::optional<uint16_t> scanner_data_port_;
-  boost::optional<uint16_t> scanner_control_port_;
+  uint16_t scanner_data_port_{ constants::DATA_PORT_OF_SCANNER_DEVICE };
+  uint16_t scanner_control_port_{ constants::CONTROL_PORT_OF_SCANNER_DEVICE };
 
   boost::optional<DefaultScanRange> scan_range_{};
   bool diagnostics_enabled_{ false };

--- a/src/scanner_configuration.cpp
+++ b/src/scanner_configuration.cpp
@@ -19,11 +19,7 @@ namespace psen_scan_v2
 {
 bool ScannerConfiguration::isValid() const
 {
-  // clang-format off
-  return host_ip_     && host_data_port_    && host_control_port_ &&
-         scanner_ip_  && scanner_data_port_ && scanner_control_port_ &&
-         scan_range_;
-  // clang-format on
+  return host_ip_ && scanner_ip_ && scan_range_;
 }
 
 uint32_t ScannerConfiguration::hostIp() const
@@ -33,12 +29,12 @@ uint32_t ScannerConfiguration::hostIp() const
 
 uint16_t ScannerConfiguration::hostUDPPortData() const
 {
-  return *host_data_port_;
+  return host_data_port_;
 }
 
 uint16_t ScannerConfiguration::hostUDPPortControl() const
 {
-  return *host_control_port_;
+  return host_control_port_;
 }
 
 uint32_t ScannerConfiguration::clientIp() const
@@ -48,12 +44,12 @@ uint32_t ScannerConfiguration::clientIp() const
 
 uint16_t ScannerConfiguration::scannerDataPort() const
 {
-  return *scanner_data_port_;
+  return scanner_data_port_;
 }
 
 uint16_t ScannerConfiguration::scannerControlPort() const
 {
-  return *scanner_control_port_;
+  return scanner_control_port_;
 }
 
 const DefaultScanRange& ScannerConfiguration::scanRange() const


### PR DESCRIPTION
## Description

In addition to e8f88cd3d103a5daf77df4aff8f8da9a1ae1a4c0, these changes  allow the user to build a `ScannerConfiguration `without setting the ports.

#107 will make use of it.

### Things to add, update or check by the maintainers before this PR can be merged.

* [x] Public api function documentation
* [x] Architecture documentation reflects actual code structure
* [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [x] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [x] CHANGELOG.rst updated
* [x] Copyright headers
* [x] Examples

### Review Checklist
* [x] Soft- and hardware architecture (diagrams and description)
* [x] Test review (test plan and individual test cases)
* [x] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [x] When is the new feature released? -> Not urgent
* [x] Which dependent packages do have to be released simultaneously? -> None
