### PR TITLE
Fix compilation of hwtest_scan_compare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,8 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(hwtest_scan_compare
       ${catkin_LIBRARIES}
       ${pilz_testutils_LIBRARIES}
+      ${rosbag_LIBRARIES}
+      fmt::fmt
     )
   endif()
 


### PR DESCRIPTION
The hardware test fails to compile on the main branch (91104569fdeb31e229fa171f408eb26a085bbdcf)

Full log: [hwtest_log.txt](https://github.com/PilzDE/psen_scan_v2/files/5796777/hwtest_log.txt)

