### PR TITLE
boost header-only build

### DIFF
--- a/.github/workflows/ci_action_standalone.yml
+++ b/.github/workflows/ci_action_standalone.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies
-      run: sudo apt-get install libboost-all-dev libconsole-bridge-dev libfmt-dev
+      run: sudo apt-get install libboost-system-dev libconsole-bridge-dev libfmt-dev
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -25,7 +25,10 @@ add_compile_options(-Werror)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 ## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost 1.69) ## Boost::system is header-only since 1.69
+if(NOT Boost_FOUND)
+  find_package(Boost REQUIRED COMPONENTS system)
+endif()
 find_package(console_bridge REQUIRED)
 find_package(fmt REQUIRED)
 
@@ -36,6 +39,7 @@ find_package(fmt REQUIRED)
 include_directories(
   include
   ${console_bridge_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 set(${PROJECT_NAME}_sources
@@ -53,7 +57,7 @@ set(${PROJECT_NAME}_sources
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 target_link_libraries(${PROJECT_NAME}
-  Boost::system
+  ${Boost_LIBRARIES}
   ${console_bridge_LIBRARIES}
   fmt::fmt
 )

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -19,7 +19,7 @@ In order to build and use the PSENscan Standalone C++ Library you need Ubuntu ve
 
 Make sure you have all necessary tools and libraries installed:
 ```
-sudo apt-get install build-essential cmake git libboost-all-dev libconsole-bridge-dev libfmt-dev
+sudo apt-get install build-essential cmake git libboost-system-dev libconsole-bridge-dev libfmt-dev
 ```
 
 ## Get Started


### PR DESCRIPTION
if library version >= 1.69 is available there is no need to use the `system` library any longer.

## Description

This simplifies windows build(s) in the future, see https://www.boost.org/doc/libs/1_75_0/more/getting_started/windows.html

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Public api function documentation
* [ ] Architecture documentation reflects actual code structure
* [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [ ] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] CHANGELOG.rst updated
* [ ] Copyright headers
* [ ] Examples

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [ ] Which dependent packages do have to be released simultaneously?
