### PR TITLE
Fix undefined behaviour from unittest_raw_processing

### DIFF
--- a/standalone/test/unit_tests/unittest_raw_processing.cpp
+++ b/standalone/test/unit_tests/unittest_raw_processing.cpp
@@ -46,7 +46,7 @@ TYPED_TEST(RawProcessingTest, write)
 
   TypeParam data_returned;
   std::string data_str(os.str());
-  std::copy(data_str.begin(), data_str.end(), &data_returned);
+  std::copy(data_str.begin(), data_str.end(), reinterpret_cast<char*>(&data_returned));
   EXPECT_EQ(data_returned, data);
 }
 


### PR DESCRIPTION
## Description

The data read from the ostringstream must be copied byte-wise not in chunks of `sizeof(TypeParam)`.
This show up in failing tests on https://build.ros.org/job/Ndev_db__psen_scan_v2__debian_buster_amd64/15/ and
also explains why it worked with `TypeParam` == uint8_t
