### PR TITLE
fix some headers

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/scanner_reply_serialization_deserialization.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_reply_serialization_deserialization.h
@@ -16,12 +16,11 @@
 #define PSEN_SCAN_V2_STANDALONE_SCANNER_REPLY_SERIALIZATION_DESERIALIZATION_H
 
 #include <cstdint>
+#include <stdexcept>
+#include <string>
 #include <sstream>
 
-#include <boost/crc.hpp>
-
 #include "psen_scan_v2_standalone/raw_scanner_data.h"
-#include "psen_scan_v2_standalone/raw_processing.h"
 #include "psen_scan_v2_standalone/scanner_reply_msg.h"
 
 namespace psen_scan_v2_standalone

--- a/standalone/include/psen_scan_v2_standalone/scanner_v2.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_v2.h
@@ -15,7 +15,6 @@
 #ifndef PSEN_SCAN_V2_STANDALONE_SCANNER_V2_H
 #define PSEN_SCAN_V2_STANDALONE_SCANNER_V2_H
 
-#include <stdexcept>
 #include <memory>
 #include <mutex>
 #include <future>
@@ -26,10 +25,6 @@
 #include "psen_scan_v2_standalone/scanner_interface.h"
 #include "psen_scan_v2_standalone/scanner_events.h"
 #include "psen_scan_v2_standalone/scanner_state_machine.h"
-#include "psen_scan_v2_standalone/laserscan.h"
-
-#include "psen_scan_v2_standalone/udp_client.h"
-#include "psen_scan_v2_standalone/raw_scanner_data.h"
 
 #include "psen_scan_v2_standalone/watchdog.h"
 
@@ -39,6 +34,7 @@
  */
 namespace psen_scan_v2_standalone
 {
+class ScannerConfiguration;
 using namespace psen_scan_v2_standalone::scanner_protocol;
 using std::placeholders::_1;
 using std::placeholders::_2;

--- a/standalone/include/psen_scan_v2_standalone/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/start_request.h
@@ -20,12 +20,12 @@
 
 #include "psen_scan_v2_standalone/raw_scanner_data.h"
 #include "psen_scan_v2_standalone/scan_range.h"
-#include "psen_scan_v2_standalone/scanner_ids.h"
-#include "psen_scan_v2_standalone/scanner_configuration.h"
 #include "psen_scan_v2_standalone/tenth_of_degree.h"
 
 namespace psen_scan_v2_standalone
 {
+class ScannerConfiguration;
+
 /**
  * @brief Contains all things needed to define and implement a start_request::Message.
  */

--- a/standalone/src/scanner_reply_serialization_deserialization.cpp
+++ b/standalone/src/scanner_reply_serialization_deserialization.cpp
@@ -15,9 +15,12 @@
 
 #include "psen_scan_v2_standalone/scanner_reply_serialization_deserialization.h"
 
-#include <iostream>
 #include <algorithm>
 #include <cassert>
+#include <boost/crc.hpp>
+#include <sstream>
+
+#include "psen_scan_v2_standalone/raw_processing.h"
 
 namespace psen_scan_v2_standalone
 {

--- a/standalone/src/scanner_v2.cpp
+++ b/standalone/src/scanner_v2.cpp
@@ -18,6 +18,8 @@
 #include <cassert>
 #include <stdexcept>
 
+#include "psen_scan_v2_standalone/scanner_configuration.h"
+
 namespace psen_scan_v2_standalone
 {
 using namespace psen_scan_v2_standalone::scanner_protocol::scanner_events;

--- a/standalone/src/start_request.cpp
+++ b/standalone/src/start_request.cpp
@@ -15,6 +15,8 @@
 
 #include "psen_scan_v2_standalone/start_request.h"
 
+#include "psen_scan_v2_standalone/scanner_configuration.h"
+
 namespace psen_scan_v2_standalone
 {
 static constexpr TenthOfDegree MASTER_RESOLUTION{ TenthOfDegree(2u) };


### PR DESCRIPTION
reported by include-what-you-use and forward-declare ScannerConfiguration

The full log is attached:
[iwyu.out.txt](https://github.com/PilzDE/psen_scan_v2/files/5881341/iwyu.out.txt)

I've cleaned the header files as suggested. If anyone wants to additionally clean up the cpp files, see the output above.

## Description

These changes clean up included headers.

### Review Checklist
* [x] Code (coding rules, style guide)
