### PR TITLE
try several simplifications

### DIFF
--- a/.github/workflows/ci_action_win_standalone.yml
+++ b/.github/workflows/ci_action_win_standalone.yml
@@ -7,11 +7,7 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [windows-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: [windows-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,34 +21,24 @@ jobs:
     - name: Clone fmt
       shell: bash
       working-directory: ${{runner.workspace}}
-      run: |
-        git clone https://github.com/fmtlib/fmt.git --depth 1 --branch 6.1.2
-        dir
+      run: git clone https://github.com/fmtlib/fmt.git --depth 1 --branch 6.1.2
 
     - name: Install fmt
       shell: cmd
       working-directory: ${{runner.workspace}}/fmt
       run: |
-        dir
         cmake -G "Visual Studio 16 2019" .
-        cmake --build . --config Release --target ALL_BUILD
-        cmake --build . --config Release --target INSTALL
-
-    - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/psen_scan_v2/standalone/build
+        cmake --build . --config %BUILD_TYPE% --target ALL_BUILD
+        cmake --build . --config %BUILD_TYPE% --target INSTALL
 
     - name: Configure CMake
       shell: cmd
-      working-directory: ${{runner.workspace}}/psen_scan_v2/standalone/build
+      working-directory: ${{runner.workspace}}/psen_scan_v2/standalone
       run: |
-        set BOOST_ROOT=%BOOST_ROOT_1_72_0%
-        echo %BOOST_ROOT%
-        dir
-        ls
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release ^
-          -DBOOST_ROOT=%BOOST_ROOT_1_72_0% ^
+        set     BOOST_ROOT=%BOOST_ROOT_1_72_0%
+        cmake -G "Visual Studio 16 2019" -A x64 ^
           -DCMAKE_TOOLCHAIN_FILE=%VCPKG_INSTALLATION_ROOT%/scripts/buildsystems/vcpkg.cmake ^
-          ..
+          -S . -B build
 
     - name: Build
       working-directory: ${{runner.workspace}}/psen_scan_v2/standalone


### PR DESCRIPTION
* let cmake generate the build dir using -B
* skip debug dir listings
* skip -DCMAKE_BUILD_TYPE only relevant during build
  and ignored by VS2019 generator

## Description

These changes Fix # | allow the user to | improve | ...

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Public api function documentation
* [ ] Architecture documentation reflects actual code structure
* [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [ ] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [ ] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] CHANGELOG.rst updated
* [ ] Copyright headers
* [ ] Examples

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [ ] Which dependent packages do have to be released simultaneously?
