### PR TITLE
Remove dep on boost::filesystem

### DIFF
--- a/test/hw_tests/hwtest_scan_compare.cpp
+++ b/test/hw_tests/hwtest_scan_compare.cpp
@@ -16,7 +16,6 @@
 #include <ros/ros.h>
 #include <gtest/gtest.h>
 
-#include <boost/filesystem.hpp>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <functional>
@@ -30,6 +29,7 @@
 
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
+#include <rosbag/exceptions.h>
 #include <sensor_msgs/LaserScan.h>
 
 #include "psen_scan_v2/dist.h"
@@ -62,7 +62,7 @@ std::map<int16_t, NormalDist> binsFromRosbag(std::string filepath)
 class ScanComparisonTests : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
+  static void SetUpTestSuite()
   {
     ros::NodeHandle pnh{ "~" };
 
@@ -70,13 +70,20 @@ public:
     pnh.getParam("testfile", filepath);
 
     ROS_INFO_STREAM("Using testfile " << filepath);
-    if (!boost::filesystem::exists(filepath))
-    {
-      ROS_ERROR_STREAM("File " << filepath << " not found!");
-      FAIL();
-    }
 
-    bins_expected_ = binsFromRosbag(filepath);
+    try
+    {
+      bins_expected_ = binsFromRosbag(filepath);
+    }
+    catch (const rosbag::BagIOException& e)
+    {
+      FAIL() << "File " << filepath
+             << " could not be opened. Make sure the file exists and the you have sufficient rights to open it.";
+    }
+    catch (const rosbag::BagException& e)
+    {
+      FAIL() << "There was an error opening " << filepath;
+    }
 
     ASSERT_TRUE(pnh.getParam("test_duration", test_duration_));
   }


### PR DESCRIPTION
## Description

Boost filesystem was only used in one test to check the existence of a file which would be opened by rosbag throwing. I think catching is the better solution.

### Things to add, update or check by the maintainers before this PR can be merged.

* [x] ~Public api function documentation~
* [x] ~Architecture documentation reflects actual code structure~
* [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
* [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
* [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [x] ~CHANGELOG.rst updated~
* [x] ~Copyright headers~
* [x] ~Examples~

### Review Checklist
* [x] ~Soft- and hardware architecture (diagrams and description)~
* [x] ~Test review (test plan and individual test cases)~
* [x] ~Documentation describes purpose of file(s) and responsibilities~
* [x] Code (coding rules, style guide)

### Release planning (please answer)
* [x] ~When is the new feature released?~
* [x] ~Which dependent packages do have to be released simultaneously?~
