### PR TITLE
Reorder Readme sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Package: psen_scan_v2
 
-The **psen_scan_v2** package is a ROS integration driver for the PSENscan safety laser scanner product. It lets you integrate the laser scanner data into your ROS Environment easily. Using the standard [sensor_msgs/LaserScan][] message format ensures compatibility with other laserscan-post-processing nodes such as [gmapping][]. For a general overview and link collection we refer to the [wiki page](http://wiki.ros.org/psen_scan_v2).
+The **psen_scan_v2** package is a ROS integration driver for the PSENscan safety laser scanner product. It lets you integrate the laser scanner data into your ROS Environment easily. Using the standard [sensor_msgs/LaserScan][] message format ensures compatibility with other laserscan-post-processing nodes such as [gmapping][]. For a general overview, link collection and tutorials we refer to the [ROS wiki page](http://wiki.ros.org/psen_scan_v2).
 
 <p align="center">
 <img src="img/PSENscan.jpg" alt="PILZ safety laser scanner" title="PILZ safety laser scanner">
@@ -23,14 +23,14 @@ PSENscan firmware >= 3.1.0 is supported on the following models:
 | PSEN sc M 5.5 08-12	5.5 m | safety zone, 8 or 12-pin exchangeable memory module	| 6D000017 |
 
 ## C++ standalone library
-If you are interested in using the PSENscan safety laser scanner without ROS, please take a look at our C++ standalone library. You can read more about it [here](https://github.com/PilzDE/psen_scan_v2/blob/main/standalone/README.md)
+If you are interested in using the PSENscan safety laser scanner without ROS, please take a look at our C++ standalone library. You can read more about it [in the `standalone` folder](https://github.com/PilzDE/psen_scan_v2/blob/main/standalone/README.md)
 
 ## Table of Contents
 
 1. [Installation](#installation)
 2. [Usage](#usage)
    + [Parameters](#parameters)
-   + [Further Parameters (optional)](#further-parameters--optional-)
+   + [Further Parameters (optional)](#further-parameters-optional)
    + [Published Topics](#published-topics)
    + [TF Frames](#tf-frames)
    + [Defining the scan range](#defining-the-scan-range)
@@ -52,9 +52,9 @@ sudo apt install ros-$ROS_DISTRO-psen-scan-v2
 ```
 
 ## Usage
-To start reading from the safety laser scanner and publishing complete scans execute `roslaunch psen_scan_v2 psen_scan_v2.launch` in a command line. This will launch the ROS Node with the default configuration.
+To start reading data from the safety laser scanner and publishing scans execute `roslaunch psen_scan_v2 psen_scan_v2.launch` in a command line. This will launch the ROS Node with the default configuration.
 
-If you wish to set parameters from the command line, add them to the end of the command as follows: `parameter:=value`, separated by spaces.
+If you wish to set parameters from the command line, add them to the end of the command as `parameter:=value`, separated by spaces.
 
 ```bash
 roslaunch psen_scan_v2 psen_scan_v2.launch sensor_ip:=192.168.0.10 host_ip:=192.168.0.20 host_udp_port_data:=3050

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Package: psen_scan_v2
 
-The **psen_scan_v2** package is a ROS integration of the PSENscan safety laser scanner product. It lets you integrate the laser scanner data into your ROS Environment easily. Using the standard [sensor_msgs/LaserScan][] message format ensures compatibility with other laserscan-post-processing nodes such as [gmapping][]. For a general overview and link collection we refer to the [wiki page](http://wiki.ros.org/psen_scan_v2).
+The **psen_scan_v2** package is a ROS integration driver for the PSENscan safety laser scanner product. It lets you integrate the laser scanner data into your ROS Environment easily. Using the standard [sensor_msgs/LaserScan][] message format ensures compatibility with other laserscan-post-processing nodes such as [gmapping][]. For a general overview and link collection we refer to the [wiki page](http://wiki.ros.org/psen_scan_v2).
 
 <p align="center">
 <img src="img/PSENscan.jpg" alt="PILZ safety laser scanner" title="PILZ safety laser scanner">
@@ -22,52 +22,44 @@ PSENscan firmware >= 3.1.0 is supported on the following models:
 | PSEN sc M 3.0 08-12	3.0 m | safety zone, 8 or 12-pin exchangeable memory module	| 6D000016 |
 | PSEN sc M 5.5 08-12	5.5 m | safety zone, 8 or 12-pin exchangeable memory module	| 6D000017 |
 
+## C++ standalone library
+If you are interested in using the PSENscan safety laser scanner without ROS, please take a look at our C++ standalone library. You can read more about it [here](https://github.com/PilzDE/psen_scan_v2/blob/main/standalone/README.md)
+
 ## Table of Contents
 
 1. [Installation](#installation)
-2. [Build Status](#build-status)
-3. [Setup](#setup)
-4. [ROS API](#ros-api)
-5. [Usage](#usage)
-6. [C++ standalone library](#c++-standalone-library)
+2. [Usage](#usage)
+   + [Parameters](#parameters)
+   + [Further Parameters (optional)](#further-parameters--optional-)
+   + [Published Topics](#published-topics)
+   + [TF Frames](#tf-frames)
+   + [Defining the scan range](#defining-the-scan-range)
+   + [Adjust expert parameters](#adjust-expert-parameters)
+3. [Developer Information](#developer-information)
+   + [Build Status](#build-status)
+   + [Branching model](#branching-model)
+   + [Test concept](#test-concept)
+4. [Migration](#migration)
 
 ## Installation
+Needed Equipment:
+- PSENscan safety laser scanner
+- ROS Machine
+
 To use the package, you can install prebuilt packages with
 ```
 sudo apt install ros-$ROS_DISTRO-psen-scan-v2
 ```
 
-## Migration
-To update your ROS environment from the former `psen_scan` package (which supported firmware versions up to 3.0), please execute the following steps:
-1. Update scanner firmware using PSENscan Configurator (unless the device has firmware 3.1 already)
-2. Install the new ROS package ```sudo apt install ros-$ROS_DISTRO-psen-scan-v2```
-3. Replace the launch file arguments:
-	* `password` and `x_axis_rotation` are obsolete and should be dropped
-	* `angle_start` and `angle_end` are now in radians, in direction of the x axis of the scanner tf frame
-4. In your application launch file / roslaunch command: replace all occurrences of `psen_scan` with `psen_scan_v2`
+## Usage
+To start reading from the safety laser scanner and publishing complete scans execute `roslaunch psen_scan_v2 psen_scan_v2.launch` in a command line. This will launch the ROS Node with the default configuration.
 
-## Build Status
-| Platform | Melodic | Noetic |
-| -------- | ------- | ------ |
-| CI | [![CI-Melodic](https://github.com/PilzDE/psen_scan_v2/workflows/CI-Melodic/badge.svg?event=push)](https://github.com/PilzDE/psen_scan_v2/actions?query=event%3Apush+workflow%3ACI-Melodic+branch%3Amain) | [![CI-Noetic](https://github.com/PilzDE/psen_scan_v2/workflows/CI-Noetic/badge.svg?event=push)](https://github.com/PilzDE/psen_scan_v2/actions?query=event%3Apush+workflow%3ACI-Noetic+branch%3Amain) |
-| Buildfarm src | [![Build Status](http://build.ros.org/job/Msrc_uB__psen_scan_v2__ubuntu_bionic__source/badge/icon)](http://build.ros.org/job/Msrc_uB__psen_scan_v2__ubuntu_bionic__source/) | [![Build Status](http://build.ros.org/job/Nsrc_uF__psen_scan_v2__ubuntu_focal__source/badge/icon)](http://build.ros.org/job/Nsrc_uF__psen_scan_v2__ubuntu_focal__source/) |
-| Buildfarm bin | [![Build Status](http://build.ros.org/job/Mbin_uB64__psen_scan_v2__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros.org/job/Mbin_uB64__psen_scan_v2__ubuntu_bionic_amd64__binary/) | [![Build Status](http://build.ros.org/job/Nbin_uF64__psen_scan_v2__ubuntu_focal_amd64__binary/badge/icon)](http://build.ros.org/job/Nbin_uF64__psen_scan_v2__ubuntu_focal_amd64__binary/) |
+If you wish to set parameters from the command line, add them to the end of the command as follows: `parameter:=value`, separated by spaces.
 
-
-## Branching model
-`main` is considered to be the active development branch, it targets the ROS distributions `melodic` and `noetic`.
-
-## Setup
-
-Needed Equipment:
-- PSENscan safety laser scanner
-- ROS Machine
-
-## ROS API
-
-### Published Topics
-/laser_scanner/scan ([sensor_msgs/LaserScan][])<br/>
-Publishes a complete scan from the PSENscan safety laser scanner.
+```bash
+roslaunch psen_scan_v2 psen_scan_v2.launch sensor_ip:=192.168.0.10 host_ip:=192.168.0.20 host_udp_port_data:=3050
+```
+This example configures the safety laser scanner at 192.168.0.10 to send it´s frames to 192.168.0.20:3050.
 
 ### Parameters
 _host_ip_ (_string_, default: "192.168.0.50")<br/>
@@ -93,17 +85,11 @@ Start angle of measurement. (Radian)
 _angle_end_ (_double_, default: 2.40 (= 137.5 deg))<br/>
 End angle of measurement. (Radian)
 
-## Usage
-To start reading from the safety laser scanner and publishing complete scans execute `roslaunch psen_scan_v2 psen_scan_v2.launch` in a command line. This will launch the ROS Node with the default configuration.
+### Published Topics
+/laser_scanner/scan ([sensor_msgs/LaserScan][])<br/>
+Publishes a complete scan from the PSENscan safety laser scanner.
 
-If you wish to set parameters from the command line, add them to the end of the command as follows: `parameter:=value`, separated by spaces.
-
-```bash
-roslaunch psen_scan_v2 psen_scan_v2.launch sensor_ip:=192.168.0.10 host_ip:=192.168.0.20 host_udp_port_data:=3050
-```
-This example configures the safety laser scanner at 192.168.0.10 to send it´s frames to 192.168.0.20:3050.
-
-## TF Frames
+### TF Frames
 The location of the TF frames is shown in the image below.
 These names are defined by the aforementioned launchfile parameter `prefix`.
 Changing them is necessary for instance when running multiple scanners.
@@ -111,7 +97,7 @@ Changing them is necessary for instance when running multiple scanners.
 <img src="img/frames.png" width="800px" alt="PILZ safety laser scanner frames" title="frames">
 </p>
 
-## Defining the scan range
+### Defining the scan range
 You can adjust the scan field to your needs by changing _angle_start_ and _angle_end_.
 The published ([sensor_msgs/LaserScan][]) will only contain data within the given angle limits.
 Both limits are defined within the _laser_1_scan_ frame as shown in the image below.
@@ -125,11 +111,29 @@ If you've created an application package with your own launch file as described 
 [tutorials](http://wiki.ros.org/psen_scan_v2/Tutorials/),
 you can easily adjust the aforementioned configuration parameters.
 
-## C++ standalone library
-If you are interested in using the PSENscan safety laser scanner without ROS, please take a look at our C++ standalone library. You can read more about it [here](https://github.com/PilzDE/psen_scan_v2/blob/main/standalone/README.md)
+## Developer Information
+### Build Status
+| Platform | Melodic | Noetic |
+| -------- | ------- | ------ |
+| CI | [![CI-Melodic](https://github.com/PilzDE/psen_scan_v2/workflows/CI-Melodic/badge.svg?event=push)](https://github.com/PilzDE/psen_scan_v2/actions?query=event%3Apush+workflow%3ACI-Melodic+branch%3Amain) | [![CI-Noetic](https://github.com/PilzDE/psen_scan_v2/workflows/CI-Noetic/badge.svg?event=push)](https://github.com/PilzDE/psen_scan_v2/actions?query=event%3Apush+workflow%3ACI-Noetic+branch%3Amain) |
+| Buildfarm src | [![Build Status](http://build.ros.org/job/Msrc_uB__psen_scan_v2__ubuntu_bionic__source/badge/icon)](http://build.ros.org/job/Msrc_uB__psen_scan_v2__ubuntu_bionic__source/) | [![Build Status](http://build.ros.org/job/Nsrc_uF__psen_scan_v2__ubuntu_focal__source/badge/icon)](http://build.ros.org/job/Nsrc_uF__psen_scan_v2__ubuntu_focal__source/) |
+| Buildfarm bin | [![Build Status](http://build.ros.org/job/Mbin_uB64__psen_scan_v2__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros.org/job/Mbin_uB64__psen_scan_v2__ubuntu_bionic_amd64__binary/) | [![Build Status](http://build.ros.org/job/Nbin_uF64__psen_scan_v2__ubuntu_focal_amd64__binary/badge/icon)](http://build.ros.org/job/Nbin_uF64__psen_scan_v2__ubuntu_focal_amd64__binary/) |
 
-## Test concept
+
+### Branching model
+`main` is considered to be the active development branch, it targets the ROS distributions `melodic` and `noetic`.
+
+### Test concept
 ![psen_scan_test_concept](doc/test_architecture.svg)
+
+## Migration
+To update your ROS environment from the former `psen_scan` package (which supported firmware versions up to 3.0), please execute the following steps:
+1. Update scanner firmware using PSENscan Configurator (unless the device has firmware 3.1 already)
+2. Install the new ROS package ```sudo apt install ros-$ROS_DISTRO-psen-scan-v2```
+3. Replace the launch file arguments:
+	* `password` and `x_axis_rotation` are obsolete and should be dropped
+	* `angle_start` and `angle_end` are now in radians, in direction of the x axis of the scanner tf frame
+4. In your application launch file / roslaunch command: replace all occurrences of `psen_scan` with `psen_scan_v2`
 
 ## You need further information?
 Our international hotline staff will support you individually about our ROS packages at

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ If you are interested in using the PSENscan safety laser scanner without ROS, pl
    + [Published Topics](#published-topics)
    + [TF Frames](#tf-frames)
    + [Defining the scan range](#defining-the-scan-range)
-   + [Adjust expert parameters](#adjust-expert-parameters)
 3. [Developer Information](#developer-information)
    + [Build Status](#build-status)
    + [Branching model](#branching-model)
@@ -60,6 +59,9 @@ If you wish to set parameters from the command line, add them to the end of the 
 roslaunch psen_scan_v2 psen_scan_v2.launch sensor_ip:=192.168.0.10 host_ip:=192.168.0.20 host_udp_port_data:=3050
 ```
 This example configures the safety laser scanner at 192.168.0.10 to send it´s frames to 192.168.0.20:3050.
+
+The [tutorials](http://wiki.ros.org/psen_scan_v2/Tutorials/) describe how to create an application package with your own launch file, where
+you can easily adjust the configuration parameters.
 
 ### Parameters
 _host_ip_ (_string_, default: "192.168.0.50")<br/>
@@ -105,11 +107,6 @@ Both limits are defined within the _laser_1_scan_ frame as shown in the image be
 <p align="center">
 <img src="img/angle_limits.png" width="800px" alt="Limit visualization" title="Limit visualization">
 </p>
-
-### Adjust expert parameters
-If you've created an application package with your own launch file as described in the
-[tutorials](http://wiki.ros.org/psen_scan_v2/Tutorials/),
-you can easily adjust the aforementioned configuration parameters.
 
 ## Developer Information
 ### Build Status


### PR DESCRIPTION
## Description

The table of contents was broken - while fixing it I also re-ordered the subsections. What do you think?
* Put C++ library at the beginning
* group parameters and their explanation under 'Usage'
* group build status, branching and test concept as new section 'developer information'
and create TOC including missing paragraphs with the help of https://ecotrust-canada.github.io/markdown-toc/

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] ~Public api function documentation~
* [ ] ~~Architecture documentation reflects actual code structure~~
* [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [ ] ~~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~~
* [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] ~CHANGELOG.rst updated~
* [ ] ~Copyright headers~
* [ ] ~Examples~

### Review Checklist
* [ ] ~~Soft- and hardware architecture (diagrams and description)~~
* [ ] ~~Test review (test plan and individual test cases)~~
* [ ] ~~Documentation describes purpose of file(s) and responsibilities~~
* [ ] ~~Code (coding rules, style guide)~~

### Release planning (please answer)
* [ ] ~When is the new feature released?~
* [ ] ~Which dependent packages do have to be released simultaneously?~
