### PR TITLE
drop expert parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,10 @@ you can easily adjust the configuration parameters.
 _sensor_ip_ (_string_, default: "192.168.0.10")<br/>
 IP-Address of safety laser scanner.
 
-### Further Parameters (optional)
-
-_host_ip_ (_string_, default: "auto")<br/>
-IP-Address of host machine. The IP of the local machine is used by default.
-
-_host_udp_port_data_ (_int_, default: 55115)<br/>
-UDP Port on which monitoring frames (scans) should be received.
-
-_host_udp_port_control_ (_int_, default: 55116)<br/>
-UDP Port used to send commands (start/stop) and receive the corresponding replies.
+### Optional Parameters
 
 _prefix_ (_string_, default: "laser_1")<br/>
-Name of this scanner that can be changed to differentiate between multiple units.
+Name of this scanner that can be changed to differentiate between multiple devices.
 
 _angle_start_ (_double_, default: -2.40 (= -137.5 deg))<br/>
 Start angle of measurement. (Radian)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ If you are interested in using the PSENscan safety laser scanner without ROS, pl
 1. [Installation](#installation)
 2. [Usage](#usage)
    + [Parameters](#parameters)
-   + [Further Parameters (optional)](#further-parameters-optional)
+   + [Optional Parameters](#optional-parameters)
+   + [Expert Parameters (optional)](#expert-parameters-optional)
    + [Published Topics](#published-topics)
    + [TF Frames](#tf-frames)
    + [Defining the scan range](#defining-the-scan-range)
@@ -78,6 +79,17 @@ Start angle of measurement. (Radian)
 
 _angle_end_ (_double_, default: 2.40 (= 137.5 deg))<br/>
 End angle of measurement. (Radian)
+
+### Expert Parameters (optional)
+
+_host_ip_ (_string_, default: "auto")<br/>
+IP-Address of host machine. The IP of the local machine is used by default.
+
+_host_udp_port_data_ (_int_, default: 55115)<br/>
+UDP Port on which monitoring frames (scans) should be received.
+
+_host_udp_port_control_ (_int_, default: 55116)<br/>
+UDP Port used to send commands (start/stop) and receive the corresponding replies.
 
 ### Published Topics
 /laser_scanner/scan ([sensor_msgs/LaserScan][])<br/>


### PR DESCRIPTION
that are only advanced usage documented in the launch file comments

## Description

For easier getting started the expert parameters are documented inside the launch file only. This makes it much easier, to find the paramters that are meant to change for first-time-users.