### PR TITLE
Add missing find_package() calls to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(Boost 1.69) ## Boost::system is header-only since 1.69
 if(NOT Boost_FOUND)
+  #catkin_lint: ignore_once shadowed_find
   find_package(Boost REQUIRED COMPONENTS system)
 endif()
 find_package(console_bridge REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
+## System dependencies are found with CMake's conventions
+find_package(Boost 1.69) ## Boost::system is header-only since 1.69
+if(NOT Boost_FOUND)
+  find_package(Boost REQUIRED COMPONENTS system)
+endif()
+find_package(console_bridge REQUIRED)
+find_package(fmt REQUIRED)
+
 catkin_package(
   CATKIN_DEPENDS
     roscpp
@@ -101,7 +109,7 @@ set(${PROJECT_NAME}_standalone_sources
 )
 
 add_library(
-  ${PROJECT_NAME}_standalone 
+  ${PROJECT_NAME}_standalone
   ${${PROJECT_NAME}_standalone_sources}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,6 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   find_package(roslaunch REQUIRED)
   find_package(pilz_testutils REQUIRED)
-  find_package(fmt REQUIRED)
 
   if(ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)


### PR DESCRIPTION
## Description

Fixes an error introduced in a66adf5797e7d1e57683adbc1761a83e398d558d, see https://build.ros.org/job/Mdev__psen_scan_v2__ubuntu_bionic_amd64/71

### Things to add, update or check by the maintainers before this PR can be merged.

* [x] ~~Public api function documentation~~
* [x] ~~Architecture documentation reflects actual code structure~~
* [x] ~~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~~
* [x] ~~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~~
* [x] ~~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~~
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] ~~CHANGELOG.rst updated~~
* [x] ~~Copyright headers~~
* [x] ~~Examples~~

### Review Checklist
* [x] ~~Soft- and hardware architecture (diagrams and description)~~
* [x] ~~Test review (test plan and individual test cases)~~
* [x] ~~Documentation describes purpose of file(s) and responsibilities~~
* [x] Code (coding rules, style guide)

### Release planning (please answer)
* [x] When is the new feature released?
Release is overdue ...
* [x] Which dependent packages do have to be released simultaneously?
None
