### PR TITLE
Remove warnings from doxygen for boost::msm

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -47,6 +47,7 @@ DEFAULT_STATE_IMPL(WaitForStopReply)
 
 DEFAULT_ON_ENTRY_IMPL(Idle)
 
+// \cond Ignore "was not declared or defined" warnings from doxygen
 template <class Event, class FSM>
 void ScannerProtocolDef::Idle::on_exit(Event const&, FSM& fsm)
 {
@@ -98,6 +99,7 @@ void ScannerProtocolDef::Stopped::on_entry(Event const&, FSM& fsm)
 
 DEFAULT_ON_EXIT_IMPL(Stopped)
 
+// \endcond
 //+++++++++++++++++++++++++++++++++ Actions +++++++++++++++++++++++++++++++++++
 
 template <class T>


### PR DESCRIPTION
## Description

Removes warnings
```
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:53: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::Idle::on_exit' was not declared or defined.
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:61: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::WaitForStartReply::on_entry' was not declared or defined.
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:69: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::WaitForStartReply::on_exit' was not declared or defined.
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:77: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::WaitForMonitoringFrame::on_entry' was not declared or defined.
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:87: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::WaitForMonitoringFrame::on_exit' was not declared or defined.
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h:95: warning: documented symbol 'void psen_scan_v2_standalone::protocol_layer::ScannerProtocolDef::Stopped::on_entry' was not declared or defined.
```

Actually this is a preparation for https://github.com/PilzDE/psen_scan_v2/pull/185

Maybe there is a better way to handle this I am not aware about

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] Copyright headers
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~
