### PR TITLE
Use default args for start_request::serialize

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -46,7 +46,6 @@ public:
 
   friend data_conversion_layer::RawData serialize(const data_conversion_layer::start_request::Message&,
                                                   const uint32_t&);
-  friend data_conversion_layer::RawData serialize(const data_conversion_layer::start_request::Message&);
 
 private:
   /**

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request_serialization.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request_serialization.h
@@ -24,8 +24,10 @@ namespace data_conversion_layer
 {
 namespace start_request
 {
-RawData serialize(const data_conversion_layer::start_request::Message& start_request, const uint32_t& seq_number);
-RawData serialize(const data_conversion_layer::start_request::Message& start_request);
+static const uint32_t DEFAULT_SEQ_NUMBER{ 0 };
+
+RawData serialize(const data_conversion_layer::start_request::Message& start_request,
+                  const uint32_t& seq_number = DEFAULT_SEQ_NUMBER);
 }  // namespace start_request
 }  // namespace data_conversion_layer
 }  // namespace psen_scan_v2_standalone

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "psen_scan_v2_standalone/data_conversion_layer/start_request_serialization.h"
 namespace psen_scan_v2_standalone
 {
 namespace protocol_layer
@@ -111,7 +112,8 @@ inline void ScannerProtocolDef::sendStartRequest(const T& event)
     args_->config_.setHostIp(host_ip.to_ulong());
     PSENSCAN_INFO("StateMachine", "No host ip set! Using local ip: {}", host_ip.to_string());
   }
-  args_->control_client_->write(serialize(data_conversion_layer::start_request::Message(args_->config_)));
+  args_->control_client_->write(
+      data_conversion_layer::start_request::serialize(data_conversion_layer::start_request::Message(args_->config_)));
 }
 
 inline void ScannerProtocolDef::handleStartRequestTimeout(const scanner_events::StartTimeout& event)

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -36,7 +36,6 @@ namespace start_request
 {
 static constexpr std::size_t SIZE{ 58 };  // See protocol description
 static constexpr uint64_t RESERVED{ 0 };
-static constexpr uint32_t DEFAULT_SEQ_NUMBER{ 0 };
 
 static const uint32_t OPCODE{ 0x35 };
 }  // namespace start_request
@@ -121,9 +120,5 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
   return raw_data_with_crc;
 }
 
-RawData data_conversion_layer::start_request::serialize(const data_conversion_layer::start_request::Message& msg)
-{
-  return serialize(msg, data_conversion_layer::start_request::DEFAULT_SEQ_NUMBER);
-}
 }  // namespace data_conversion_layer
 }  // namespace psen_scan_v2_standalone

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -23,6 +23,7 @@
 #include "psen_scan_v2_standalone/scanner_configuration.h"
 #include "psen_scan_v2_standalone/scanner_config_builder.h"
 #include "psen_scan_v2_standalone/data_conversion_layer/start_request.h"
+#include "psen_scan_v2_standalone/data_conversion_layer/start_request_serialization.h"
 #include "psen_scan_v2_standalone/scan_range.h"
 
 #include "psen_scan_v2_standalone/data_conversion_layer/raw_data_test_helper.h"
@@ -174,7 +175,8 @@ TEST_F(StartRequestTest, crcShouldBeCorrectIfDiagnosticIsEnabled)
 {
   const ScannerConfiguration config{ createConfig(true) };
 
-  const auto raw_start_request{ serialize(data_conversion_layer::start_request::Message(config)) };
+  const auto raw_start_request{ data_conversion_layer::start_request::serialize(
+      data_conversion_layer::start_request::Message(config)) };
   const std::array<unsigned char, 4> expected_crc = { 0x18, 0x5b, 0xd5, 0x55 };  // see wireshark for this number
   for (size_t i = 0; i < expected_crc.size(); ++i)
   {


### PR DESCRIPTION
## Description

Actually occured while preparing for https://github.com/PilzDE/psen_scan_v2/pull/185
where a error is printed by `rosdoc_lite`
```
/home/alex/catkin_ws_rosdoc_ci/src/psen_scan_v2/standalone/src/data_conversion_layer/start_request_serialization.cpp:124: warning: no uniquely matching class member found for 
  RawData psen_scan_v2_standalone::data_conversion_layer::data_conversion_layer::start_request::serialize(const data_conversion_layer::start_request::Message &msg)
```

Nevertheless using default arguments should be the better way here.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~hich dependent packages do have to be released simultaneously?~
