### PR TITLE
Infinity treatment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Forthcoming
 * Default scan range changed to [-137.4..137.4]deg at 0.1 deg resolution
 * Add options for modifying resolution and enabling intensities
 * Add launchfile option for disabling rviz at startup (default: enable)
+* Handle the infinity codes from the scanner correctly
 * Contributors: Pilz GmbH and Co. KG
 
 

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/monitoring_frame_deserialization.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/monitoring_frame_deserialization.h
@@ -49,6 +49,8 @@ static constexpr uint32_t ONLINE_WORKING_MODE{ 0x00 };
 static constexpr uint32_t GUI_MONITORING_TRANSACTION{ 0x05 };
 static constexpr uint16_t NUMBER_OF_BYTES_SCAN_COUNTER{ 4 };
 static constexpr uint16_t NUMBER_OF_BYTES_SINGLE_MEASUREMENT{ 2 };
+static constexpr uint16_t NO_SIGNAL_ARRIVED{ 59956 };
+static constexpr uint16_t SIGNAL_TOO_LATE{ 59958 };
 static constexpr uint16_t NUMBER_OF_BYTES_SINGLE_INTENSITY{ 2 };
 
 /**

--- a/standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
+++ b/standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
@@ -55,7 +55,7 @@ static constexpr double toMeter(const uint16_t& value)
 {
   if ((value == NO_SIGNAL_ARRIVED) || (value == SIGNAL_TOO_LATE))
   {
-    return INFINITY;
+    return std::numeric_limits<double>::infinity();
   }
   return static_cast<double>(value) / 1000.;
 }

--- a/standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
+++ b/standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
@@ -53,6 +53,10 @@ FixedFields::FixedFields(DeviceStatus device_status,
 
 static constexpr double toMeter(const uint16_t& value)
 {
+  if ((value == NO_SIGNAL_ARRIVED) || (value == SIGNAL_TOO_LATE))
+  {
+    return INFINITY;
+  }
   return static_cast<double>(value) / 1000.;
 }
 

--- a/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
+++ b/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
@@ -58,8 +58,13 @@ RawData serialize(const data_conversion_layer::monitoring_frame::Message& frame)
       static_cast<AdditionalFieldHeader::Id>(AdditionalFieldHeaderID::measurements),
       frame.measurements_.size() * NUMBER_OF_BYTES_SINGLE_MEASUREMENT);
   write(os, measurements_header);
-  data_conversion_layer::raw_processing::writeArray<uint16_t, double>(
-      os, frame.measurements_, [](double elem) { return (static_cast<uint16_t>(std::round(elem * 1000.))); });
+  data_conversion_layer::raw_processing::writeArray<uint16_t, double>(os, frame.measurements_, [](double elem) {
+    if (elem == INFINITY)
+    {
+      return NO_SIGNAL_ARRIVED;
+    }
+    return (static_cast<uint16_t>(std::round(elem * 1000.)));
+  });
 
   if (!frame.intensities_.empty())
   {

--- a/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
+++ b/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
@@ -59,7 +59,7 @@ RawData serialize(const data_conversion_layer::monitoring_frame::Message& frame)
       frame.measurements_.size() * NUMBER_OF_BYTES_SINGLE_MEASUREMENT);
   write(os, measurements_header);
   data_conversion_layer::raw_processing::writeArray<uint16_t, double>(os, frame.measurements_, [](double elem) {
-    if (elem == INFINITY)
+    if (elem == std::numeric_limits<double>::infinity())
     {
       return NO_SIGNAL_ARRIVED;
     }

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
@@ -84,7 +84,7 @@ TEST(MonitoringFrameSerializationTest, shouldSerializeAndDeserializeFrameConsist
       util::TenthOfDegree(25),
       util::TenthOfDegree(1),
       456,
-      { 10, 20, 30, 40 },
+      { 10, 20, INFINITY, 40 },
       { 15, 25, 35, 45 },
       { data_conversion_layer::monitoring_frame::diagnostic::Message(configuration::ScannerId::master,
                                                                      error_locations.at(0)),

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
@@ -84,7 +84,7 @@ TEST(MonitoringFrameSerializationTest, shouldSerializeAndDeserializeFrameConsist
       util::TenthOfDegree(25),
       util::TenthOfDegree(1),
       456,
-      { 10, 20, INFINITY, 40 },
+      { 10, 20, std::numeric_limits<double>::infinity(), 40 },
       { 15, 25, 35, 45 },
       { data_conversion_layer::monitoring_frame::diagnostic::Message(configuration::ScannerId::master,
                                                                      error_locations.at(0)),


### PR DESCRIPTION
## Description.

Some measurement values from the laser scanner have special meanings:

59956: no reflective signal arrived,
59958: a reflective signal arrived, but it was too late (according to our time window)

both should be published as +infinity

Before the PR the measurments are published as described above. And after the PR +infinity values are published instead of 59956 or 59958.


### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] ~Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))~
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~
