### PR TITLE
Extend operators of util::TenthDegree

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/util/tenth_of_degree.h
+++ b/standalone/include/psen_scan_v2_standalone/util/tenth_of_degree.h
@@ -65,7 +65,18 @@ public:
     return TenthOfDegree(value() * rhs);
   }
 
+  constexpr TenthOfDegree operator*(const size_t& rhs) const
+  {
+    return TenthOfDegree(value() * rhs);
+  }
+
   constexpr TenthOfDegree& operator*(const int& rhs)
+  {
+    tenth_of_degree_ = value() * rhs;
+    return *this;
+  }
+
+  constexpr TenthOfDegree& operator*(const size_t& rhs)
   {
     tenth_of_degree_ = value() * rhs;
     return *this;
@@ -102,6 +113,11 @@ public:
   constexpr bool operator==(const TenthOfDegree& rhs) const
   {
     return value() == rhs.value();
+  }
+
+  constexpr bool operator!=(const TenthOfDegree& rhs) const
+  {
+    return value() != rhs.value();
   }
 
   constexpr bool operator>=(const TenthOfDegree& rhs) const

--- a/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
+++ b/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
@@ -63,6 +63,14 @@ TEST(TenthOfDegreeTest, MultiplicationWithInteger)
   EXPECT_EQ((tenth_of_degree * int_value).value(), 6);
 }
 
+TEST(TenthOfDegreeTest, MultiplicationWithSizeT)
+{
+  util::TenthOfDegree tenth_of_degree{ 2 };
+  const size_t int_value{ 3 };
+
+  EXPECT_EQ((tenth_of_degree * int_value).value(), 6);
+}
+
 TEST(TenthOfDegreeTest, DivisionWithInteger)
 {
   util::TenthOfDegree tenth_of_degree{ 6 };
@@ -91,6 +99,12 @@ TEST(TenthOfDegreeTest, EqualityComparison)
 {
   EXPECT_TRUE(util::TenthOfDegree(1) == util::TenthOfDegree(1));
   EXPECT_FALSE(util::TenthOfDegree(1) == util::TenthOfDegree(2));
+}
+
+TEST(TenthOfDegreeTest, NotEqualityComparison)
+{
+  EXPECT_FALSE(util::TenthOfDegree(1) != util::TenthOfDegree(1));
+  EXPECT_TRUE(util::TenthOfDegree(1) != util::TenthOfDegree(2));
 }
 
 TEST(TenthOfDegreeTest, LessThanComparison)


### PR DESCRIPTION
## Description

Adds multiplication for `util::TenthDegree` and `constexpr bool operator!=(const TenthOfDegree& rhs) const`
for an upcoming PR fixing the hardware tests (-DENABLE_HARDWARE_TESTING=ON)

### Things to add, update or check by the maintainers before this PR can be merged.

- [ ] ~Public api function documentation~
- [ ] ~Architecture documentation reflects actual code structure~
- [ ] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [ ] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [ ] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [ ] ~CHANGELOG.rst updated~
- [ ] ~Copyright headers~
- [ ] ~Examples~

### Review Checklist
- [ ] ~Soft- and hardware architecture (diagrams and description)~
- [ ] Test review (test plan and individual test cases)
- [ ] Documentation describes purpose of file(s) and responsibilities
- [ ] Code (coding rules, style guide)

### Release planning (please answer)
- [ ] ~When is the new feature released?~
- [ ] ~Which dependent packages do have to be released simultaneously?~
