### PR TITLE
Fix hardware tests compile errors

### DIFF
--- a/test/include/psen_scan_v2/laserscan_validator.h
+++ b/test/include/psen_scan_v2/laserscan_validator.h
@@ -28,8 +28,7 @@
 
 #include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
 #include "psen_scan_v2_standalone/laserscan.h"
-
-#include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
+#include "psen_scan_v2_standalone/util/tenth_of_degree.h"
 
 #include "psen_scan_v2/dist.h"
 
@@ -39,8 +38,7 @@ void addScanToBin(const psen_scan_v2_standalone::LaserScan& scan, std::map<int16
 {
   for (size_t i = 0; i < scan.getMeasurements().size(); ++i)
   {
-    auto bin_addr = psen_scan_v2_standalone::data_conversion_layer::radToTenthDegree(scan.getMinScanAngle() +
-                                                                                     scan.getScanResolution() * i);
+    auto bin_addr = (scan.getMinScanAngle() + scan.getScanResolution() * i).value();
 
     if (bin.find(bin_addr) == bin.end())
     {
@@ -56,7 +54,7 @@ void addScanToBin(const sensor_msgs::LaserScan& scan, std::map<int16_t, NormalDi
   for (size_t i = 0; i < scan.ranges.size(); ++i)
   {
     auto bin_addr =
-        psen_scan_v2_standalone::data_conversion_layer::radToTenthDegree(scan->angle_min + scan->angle_increment * i);
+        psen_scan_v2_standalone::data_conversion_layer::radToTenthDegree(scan.angle_min + scan.angle_increment * i);
 
     if (bin.find(bin_addr) == bin.end())
     {


### PR DESCRIPTION
## Description
Needs #193 

With this `colcon build --cmake-args "-DENABLE_HARDWARE_TESTING=ON"` 

results in 
```
/home/alex/catkin_ws_psen_scan_v2_only/src/psen_scan_v2/test/include/psen_scan_v2/laserscan_validator.h:43:113: error: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second: [-Werror]
   43 |                                                                                      scan.getScanResolution() * i);
      | 

...

/home/alex/catkin_ws_psen_scan_v2_only/src/psen_scan_v2/test/include/psen_scan_v2/laserscan_validator.h:59:78: error: base operand of ‘->’ has non-pointer type ‘const LaserScan’ {aka ‘const sensor_msgs::LaserScan_<std::allocator<void> >’}
   59 |         psen_scan_v2_standalone::data_conversion_layer::radToTenthDegree(scan->angle_min + scan->angle_increment * i);
      |                                                                              ^~
/home/alex/catkin_ws_psen_scan_v2_only/src/psen_scan_v2/test/include/psen_scan_v2/laserscan_validator.h:59:96: error: base operand of ‘->’ has non-pointer type ‘const LaserScan’ {aka ‘const sensor_msgs::LaserScan_<std::allocator<void> >’}
   59 |         psen_scan_v2_standalone::data_conversion_layer::radToTenthDegree(scan->angle_min + scan->angle_increment * i);
      |                                                                                                ^~
cc1plus: all warnings being treated as errors
```
due to

- An ambiguity during the multiplication with `TenthDegree` resolved by #193 
- Addressing the passed `sensor_msgs::LaserScan&` as pointer. (Where ever that came from...) 

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] Copyright headers
- [x] Examples

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~
