### PR TITLE
Fixes HWTest not subscribing to topic

### DIFF
--- a/test/hw_tests/hwtest_scan_compare.cpp
+++ b/test/hw_tests/hwtest_scan_compare.cpp
@@ -105,7 +105,7 @@ TEST_F(ScanComparisonTests, simpleCompare)
 
   LaserScanValidator<ScanType> laser_scan_validator(bins_expected_);
   laser_scan_validator.reset();
-  nh.subscribe<ScanType>(
+  auto scan_subscriber = nh.subscribe<ScanType>(
       "/laser_scanner/scan",
       1000,
       boost::bind(&LaserScanValidator<ScanType>::scanCb, &laser_scan_validator, boost::placeholders::_1, window_size));


### PR DESCRIPTION
## Description

Before this change the hardwaretest wouldn't subscribe to the topic. Tbh didn't have the time so far to give it a deeper thought.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~
