### PR TITLE
Add option to modify resolution and intensities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package psen_scan_v2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add options for modifying resolution and enabling intensities
+* Contributors: Pilz GmbH and Co. KG
+
+
 0.2.1 (2021-04-19)
 ------------------
 * Fix issues with smaller angle ranges than default range (`#183 <https://github.com/PilzDE/psen_scan_v2/issues/183>`_)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(unittest_scanner_configuration
     ${catkin_LIBRARIES}
+    fmt::fmt
   )
 
   catkin_add_gtest(unittest_tenth_of_degree

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Start angle of measurement. (Radian)
 _angle_end_ (_double_, default: 2.40 (= 137.5 deg))<br/>
 End angle of measurement. (Radian)
 
+_intensities_ (_bool_, default: false)<br/>
+Publish intensities. If this is enabled, the resolution needs to be increased (at least 0.2 deg).
+
+_resolution_ (_double_, default: 0.0017 (= 0.1 deg))<br/>
+Scan resolution. (Radian) The value is rounded to a multiple of 0.1 deg.
+
 ### Expert Parameters (optional)
 
 _host_ip_ (_string_, default: "auto")<br/>

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ _intensities_ (_bool_, default: false)<br/>
 Publish intensities. If this is enabled, the resolution needs to be increased (at least 0.2 deg).
 
 _resolution_ (_double_, default: 0.0017 (= 0.1 deg))<br/>
-Scan resolution. (Radian) The value is rounded to a multiple of 0.1 deg.
+Scan angle resolution. (Radian) The value is rounded to a multiple of 0.1 deg and has to be in the range [0.1, 10] degrees.
 
 ### Expert Parameters (optional)
 

--- a/launch/psen_scan_v2.launch
+++ b/launch/psen_scan_v2.launch
@@ -28,6 +28,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- End angle of measurement in radian -->
   <arg name="angle_end" default="$(eval 137.5 /180.0 * pi)" />
 
+  <!-- Publishing of intensities -->
+  <arg name="intensities" default="false" />
+
+  <!-- Scan resolution in radian -->
+  <arg name="resolution" default="$(eval 0.1 /180.0 * pi)" />
+
   <!-- IP-Address of host machine -->
   <arg name="host_ip" default="auto" />
 
@@ -45,6 +51,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <param name="prefix" value="$(arg prefix)" />
     <param name="angle_start" value="$(arg angle_start)" />
     <param name="angle_end" value="$(arg angle_end)" />
+    <param name="intensities" value="$(arg intensities)" />
+    <param name="resolution" value="$(arg resolution)" />
     <param name="host_ip" value="$(arg host_ip)" />
     <param name="host_udp_port_data" value="$(arg host_udp_port_data)" />
     <param name="host_udp_port_control" value="$(arg host_udp_port_control)" />

--- a/launch/psen_scan_v2.launch
+++ b/launch/psen_scan_v2.launch
@@ -16,15 +16,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
 <launch>
-  <!-- IP-Address of host machine -->
-  <arg name="host_ip" default="auto" />
-
-  <!-- UDP Port on which monitoring frames (scans) should be received -->
-  <arg name="host_udp_port_data" default="55115" />
-
-  <!-- UDP Port used to send commands (start/stop) and receive the corresponding replies -->
-  <arg name="host_udp_port_control" default="55116" />
-
   <!-- IP-Address of Safety laser scanner -->
   <arg name="sensor_ip" default="192.168.0.10" />
 
@@ -37,17 +28,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- End angle of measurement in radian -->
   <arg name="angle_end" default="$(eval 137.5 /180.0 * pi)" />
 
+  <!-- IP-Address of host machine -->
+  <arg name="host_ip" default="auto" />
+
+  <!-- UDP Port on which monitoring frames (scans) should be received -->
+  <arg name="host_udp_port_data" default="55115" />
+
+  <!-- UDP Port used to send commands (start/stop) and receive the corresponding replies -->
+  <arg name="host_udp_port_control" default="55116" />
+
   <!-- Set the following to true in order to publish scan data as soon as a UDP packet is ready, instead of waiting for a full scan -->
   <arg name="fragmented_scans" default="false" />
 
   <node name="laser_scanner" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
-    <param name="host_ip" value="$(arg host_ip)" />
-    <param name="host_udp_port_data" value="$(arg host_udp_port_data)" />
-    <param name="host_udp_port_control" value="$(arg host_udp_port_control)" />
     <param name="sensor_ip" value="$(arg sensor_ip)" />
     <param name="prefix" value="$(arg prefix)" />
     <param name="angle_start" value="$(arg angle_start)" />
     <param name="angle_end" value="$(arg angle_end)" />
+    <param name="host_ip" value="$(arg host_ip)" />
+    <param name="host_udp_port_data" value="$(arg host_udp_port_data)" />
+    <param name="host_udp_port_control" value="$(arg host_udp_port_control)" />
     <param name="fragmented_scans" value="$(arg fragmented_scans)" />
   </node>
 

--- a/rosdoc.yaml
+++ b/rosdoc.yaml
@@ -1,4 +1,4 @@
 - builder: doxygen
   file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox *.md'
   exclude_patterns: 'test'
-  use_mdfile_as_mainpage: './README.md'
+  use_mdfile_as_mainpage: './doc/README.md'

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
           .scanRange(scan_range)
           .enableDiagnostics()
           .enableFragmentedScans(
-              getOptionalParamFromServer<bool>(pnh, PARAM_FRAGMENTED_SCANS, configuration::DEFAULT_FRAGMENTED_SCANS))
+              getOptionalParamFromServer<bool>(pnh, PARAM_FRAGMENTED_SCANS, configuration::FRAGMENTED_SCANS))
           .build()
     };
 

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -47,6 +47,8 @@ const std::string PARAM_ANGLE_START{ "angle_start" };
 const std::string PARAM_ANGLE_END{ "angle_end" };
 const std::string PARAM_X_AXIS_ROTATION{ "x_axis_rotation" };
 const std::string PARAM_FRAGMENTED_SCANS{ "fragmented_scans" };
+const std::string PARAM_INTENSITIES{ "intensities" };
+const std::string PARAM_RESOLUTION{ "resolution" };
 
 static const std::string DEFAULT_PREFIX = "scanner";
 
@@ -93,6 +95,9 @@ int main(int argc, char** argv)
           .enableDiagnostics()
           .enableFragmentedScans(
               getOptionalParamFromServer<bool>(pnh, PARAM_FRAGMENTED_SCANS, configuration::FRAGMENTED_SCANS))
+          .enableIntensities(getOptionalParamFromServer<bool>(pnh, PARAM_INTENSITIES, configuration::INTENSITIES))
+          .scanResolution(util::TenthOfDegree::fromRad(
+              getOptionalParamFromServer<double>(pnh, PARAM_RESOLUTION, configuration::SCAN_ANGLE_RESOLUTION)))
           .build()
     };
 

--- a/standalone/include/psen_scan_v2_standalone/configuration/default_parameters.h
+++ b/standalone/include/psen_scan_v2_standalone/configuration/default_parameters.h
@@ -30,14 +30,16 @@ static constexpr unsigned short CONTROL_PORT_OF_SCANNER_DEVICE{ 3000 };
 static constexpr unsigned short DATA_PORT_OF_HOST_DEVICE{ 55115 };
 static constexpr unsigned short CONTROL_PORT_OF_HOST_DEVICE{ 55116 };
 
-static constexpr bool DEFAULT_FRAGMENTED_SCANS{ false };
+static constexpr bool FRAGMENTED_SCANS{ false };
+static constexpr bool INTENSITIES{ false };
+static constexpr bool DIAGNOSTICS{ false };
+
+static constexpr int16_t SCAN_ANGLE_RESOLUTION{ 1 };
 
 //! @brief Start angle of measurement.
 static constexpr double DEFAULT_ANGLE_START(-data_conversion_layer::degreeToRadian(137.5));
 //! @brief  End angle of measurement.
 static constexpr double DEFAULT_ANGLE_END(data_conversion_layer::degreeToRadian(137.5));
-
-static constexpr uint16_t NUMBER_OF_SAMPLES_FULL_SCAN_MASTER{ 2750 };
 
 static constexpr double TIME_PER_SCAN_IN_S{ 0.03 };
 

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
@@ -28,6 +28,9 @@ namespace psen_scan_v2_standalone
 {
 namespace data_conversion_layer
 {
+/**
+ * @brief: Exception thrown if data received from the scanner hardware could not be processed according to protocol.
+ */
 class ScannerProtocolViolationError : public std::runtime_error
 {
 public:

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/monitoring_frame_deserialization.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/monitoring_frame_deserialization.h
@@ -141,7 +141,7 @@ std::vector<diagnostic::Message> deserializeMessages(std::istringstream& is);
 }
 
 /**
- * @brief Error indicating a problem during the extraction of the measurement data.
+ * @brief Exception thrown on problems during the extraction of the measurement data.
  */
 class DecodingFailure : public std::runtime_error
 {
@@ -150,7 +150,7 @@ public:
 };
 
 /**
- * @brief Error indicating a problem with the additional field: scan_counter
+ * @brief Exception thrown on problems with the additional field: scan_counter
  *
  * The length specified in the Header of the additional field "scan_counter"
  * must be exactly as defined in NUMBER_OF_BYTES_SCAN_COUNTER for it to be converted.

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/raw_processing.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/raw_processing.h
@@ -34,7 +34,7 @@ namespace data_conversion_layer
 namespace raw_processing
 {
 /**
- * @brief Exception which is thrown if the incoming data from the scanner cannot be processed.
+ * @brief Exception thrown if the incoming data from the scanner cannot be processed.
  */
 class StringStreamFailure : public std::runtime_error
 {

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -74,13 +74,15 @@ private:
   class DeviceSettings
   {
   public:
-    constexpr DeviceSettings(const bool diagnostics_enabled);
+    constexpr DeviceSettings(const bool diagnostics_enabled, const bool intensities_enabled);
 
   public:
-    constexpr bool isDiagnosticsEnabled() const;
+    constexpr bool diagnosticsEnabled() const;
+    constexpr bool intensitiesEnabled() const;
 
   private:
     const bool diagnostics_enabled_;
+    const bool intensities_enabled_;
   };
 
 private:
@@ -111,14 +113,19 @@ constexpr util::TenthOfDegree Message::LaserScanSettings::getResolution() const
   return resolution_;
 };
 
-constexpr Message::DeviceSettings::DeviceSettings(const bool diagnostics_enabled)
-  : diagnostics_enabled_(diagnostics_enabled)
+constexpr Message::DeviceSettings::DeviceSettings(const bool diagnostics_enabled, const bool intensities_enabled)
+  : diagnostics_enabled_(diagnostics_enabled), intensities_enabled_(intensities_enabled)
 {
 }
 
-constexpr bool Message::DeviceSettings::isDiagnosticsEnabled() const
+constexpr bool Message::DeviceSettings::diagnosticsEnabled() const
 {
   return diagnostics_enabled_;
+};
+
+constexpr bool Message::DeviceSettings::intensitiesEnabled() const
+{
+  return intensities_enabled_;
 };
 
 }  // namespace start_request

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -26,7 +26,7 @@ namespace psen_scan_v2_standalone
 namespace protocol_layer
 {
 /**
- * @brief Exception indicating problems monitoring frames of a scan round.
+ * @brief Exception indicating problems with the monitoring frames of a scan round.
  */
 class ScanRoundError : public std::runtime_error
 {

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -25,6 +25,9 @@ namespace psen_scan_v2_standalone
 {
 namespace protocol_layer
 {
+/**
+ * @brief Exception indicating problems monitoring frames of a scan round.
+ */
 class ScanRoundError : public std::runtime_error
 {
 public:
@@ -32,7 +35,7 @@ public:
 };
 
 /**
- * @brief Exception which is thrown if the incoming frame has an outdated scan_counter.
+ * @brief Exception thrown if the incoming frame has an outdated scan_counter.
  */
 class OutdatedMessageError : public ScanRoundError
 {
@@ -43,7 +46,7 @@ public:
 };
 
 /**
- * @brief Exception which is thrown if a new scan round started without the last one finishing.
+ * @brief Exception thrown if a new scan round started without the last one finishing.
  */
 class ScanRoundEndedEarlyError : public ScanRoundError
 {
@@ -57,7 +60,7 @@ public:
 };
 
 /**
- * @brief Exception which is thrown if a scan round has to many messages.
+ * @brief Exception thrown if a scan round has to many messages.
  */
 class ScanRoundOversaturatedError : public ScanRoundError
 {

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine.h
@@ -221,7 +221,7 @@ public:  // Definition of state machine via table
 private:
   // LCOV_EXCL_START
   /**
-   * @brief This error is thrown when something goes wrong with the scanner reply.
+   * @brief Exception thrown when something goes wrong with the scanner reply.
    *
    * For example an unexpected code in reply, request refused by device or unknown operation result code.
    */

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -58,10 +58,15 @@ private:
 
 inline ScannerConfiguration ScannerConfigurationBuilder::build() const
 {
-  if (!config_.isValid())
+  if (!config_.isComplete())
   {
     throw std::runtime_error("Scanner configuration not complete");
   }
+  else if (!config_.isValid())
+  {
+    throw std::invalid_argument("Requires a resolution of min: 0.2 degree when intensities are enabled");
+  }
+
   return config_;
 }
 

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -118,6 +118,10 @@ inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanRange(const
 inline ScannerConfigurationBuilder&
 ScannerConfigurationBuilder::scanResolution(const util::TenthOfDegree& scan_resolution)
 {
+  if (scan_resolution < util::TenthOfDegree(1) || scan_resolution > util::TenthOfDegree(100))
+  {
+    throw std::invalid_argument("Scan resolution has to be between 0.1 and 10 degrees.");
+  }
   config_.scan_resolution_ = scan_resolution;
   return *this;
 }

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -44,7 +44,9 @@ public:
   ScannerConfigurationBuilder& scannerDataPort(const int&);
   ScannerConfigurationBuilder& scannerControlPort(const int&);
   ScannerConfigurationBuilder& scanRange(const ScanRange&);
-  ScannerConfigurationBuilder& enableDiagnostics();
+  ScannerConfigurationBuilder& scanResolution(const util::TenthOfDegree&);
+  ScannerConfigurationBuilder& enableDiagnostics(const bool&);
+  ScannerConfigurationBuilder& enableIntensities(const bool&);
   ScannerConfigurationBuilder& enableFragmentedScans(const bool&);
 
 private:
@@ -108,13 +110,25 @@ inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanRange(const
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableDiagnostics()
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanResolution(const util::TenthOfDegree& scan_resolution)
 {
-  config_.diagnostics_enabled_ = true;
+  config_.scan_resolution_ = scan_resolution;
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableFragmentedScans(const bool& enable)
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableDiagnostics(const bool& enable=true)
+{
+  config_.diagnostics_enabled_ = enable;
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableIntensities(const bool& enable=true)
+{
+  config_.intensities_enabled_ = enable;
+  return *this;
+}
+
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableFragmentedScans(const bool& enable=true)
 {
   config_.fragmented_scans_ = enable;
   return *this;

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -64,7 +64,7 @@ inline ScannerConfiguration ScannerConfigurationBuilder::build() const
   }
   else if (!config_.isValid())
   {
-    throw std::invalid_argument("Requires a resolution of min: 0.2 degree when intensities are enabled");
+    throw std::invalid_argument("Scanner configuration not valid");
   }
 
   return config_;

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -110,25 +110,26 @@ inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanRange(const
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::scanResolution(const util::TenthOfDegree& scan_resolution)
+inline ScannerConfigurationBuilder&
+ScannerConfigurationBuilder::scanResolution(const util::TenthOfDegree& scan_resolution)
 {
   config_.scan_resolution_ = scan_resolution;
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableDiagnostics(const bool& enable=true)
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableDiagnostics(const bool& enable = true)
 {
   config_.diagnostics_enabled_ = enable;
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableIntensities(const bool& enable=true)
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableIntensities(const bool& enable = true)
 {
   config_.intensities_enabled_ = enable;
   return *this;
 }
 
-inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableFragmentedScans(const bool& enable=true)
+inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableFragmentedScans(const bool& enable = true)
 {
   config_.fragmented_scans_ = enable;
   return *this;

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -18,6 +18,7 @@
 #include <boost/optional.hpp>
 
 #include "psen_scan_v2_standalone/configuration/default_parameters.h"
+#include "psen_scan_v2_standalone/util/logging.h"
 #include "psen_scan_v2_standalone/scan_range.h"
 
 namespace psen_scan_v2_standalone
@@ -84,7 +85,12 @@ inline bool ScannerConfiguration::isComplete() const
 
 inline bool ScannerConfiguration::isValid() const
 {
-  return scan_resolution_ >= util::TenthOfDegree(2u) || !intensities_enabled_;
+  if (scan_resolution_ >= util::TenthOfDegree(2u) || !intensities_enabled_)
+  {
+    PSENSCAN_ERROR("ScannerConfiguration", "Requires a resolution of min: 0.2 degree when intensities are enabled");
+    return false;
+  }
+  return true;
 }
 
 inline boost::optional<uint32_t> ScannerConfiguration::hostIp() const

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -85,7 +85,7 @@ inline bool ScannerConfiguration::isComplete() const
 
 inline bool ScannerConfiguration::isValid() const
 {
-  if (scan_resolution_ >= util::TenthOfDegree(2u) || !intensities_enabled_)
+  if (intensities_enabled_ && scan_resolution_ < util::TenthOfDegree(2u))
   {
     PSENSCAN_ERROR("ScannerConfiguration", "Requires a resolution of min: 0.2 degree when intensities are enabled");
     return false;

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -45,8 +45,10 @@ public:
   uint16_t scannerControlPort() const;
 
   const ScanRange& scanRange() const;
+  const util::TenthOfDegree& scanResolution() const;
 
   bool diagnosticsEnabled() const;
+  bool intensitiesEnabled() const;
 
   bool fragmentedScansEnabled() const;
 
@@ -68,8 +70,10 @@ private:
   uint16_t scanner_control_port_{ configuration::CONTROL_PORT_OF_SCANNER_DEVICE };
 
   boost::optional<ScanRange> scan_range_{};
-  bool diagnostics_enabled_{ false };
-  bool fragmented_scans_{ false };
+  util::TenthOfDegree scan_resolution_{ configuration::SCAN_ANGLE_RESOLUTION };
+  bool diagnostics_enabled_{ configuration::DIAGNOSTICS };
+  bool intensities_enabled_{ configuration::INTENSITIES };
+  bool fragmented_scans_{ configuration::FRAGMENTED_SCANS };
 };
 
 inline bool ScannerConfiguration::isValid() const
@@ -112,9 +116,19 @@ inline const ScanRange& ScannerConfiguration::scanRange() const
   return *scan_range_;
 }
 
+inline const util::TenthOfDegree& ScannerConfiguration::scanResolution() const
+{
+  return scan_resolution_;
+}
+
 inline bool ScannerConfiguration::diagnosticsEnabled() const
 {
   return diagnostics_enabled_;
+}
+
+inline bool ScannerConfiguration::intensitiesEnabled() const
+{
+  return intensities_enabled_;
 }
 
 inline bool ScannerConfiguration::fragmentedScansEnabled() const

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -58,6 +58,7 @@ private:
   friend class ScannerConfigurationBuilder;
 
 private:
+  bool isComplete() const;
   bool isValid() const;
 
 private:
@@ -76,9 +77,14 @@ private:
   bool fragmented_scans_{ configuration::FRAGMENTED_SCANS };
 };
 
-inline bool ScannerConfiguration::isValid() const
+inline bool ScannerConfiguration::isComplete() const
 {
   return scanner_ip_ && scan_range_;
+}
+
+inline bool ScannerConfiguration::isValid() const
+{
+  return scan_resolution_ >= util::TenthOfDegree(2u) || !intensities_enabled_;
 }
 
 inline boost::optional<uint32_t> ScannerConfiguration::hostIp() const

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -42,6 +42,8 @@ int main(int argc, char** argv)
 {
   setLogLevel(CONSOLE_BRIDGE_LOG_INFO);
 
+  // Available configuration options are listed on
+  // http://docs.ros.org/en/melodic/api/psen_scan_v2/html/classpsen__scan__v2__standalone_1_1ScannerConfigurationBuilder.html
   ScannerConfigurationBuilder config_builder;
   config_builder.scannerIp(SCANNER_IP).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
 

--- a/standalone/src/data_conversion_layer/start_request.cpp
+++ b/standalone/src/data_conversion_layer/start_request.cpp
@@ -19,8 +19,6 @@
 
 namespace psen_scan_v2_standalone
 {
-static constexpr util::TenthOfDegree MASTER_RESOLUTION{ util::TenthOfDegree(2u) };
-
 namespace data_conversion_layer
 {
 namespace start_request
@@ -28,8 +26,8 @@ namespace start_request
 Message::Message(const ScannerConfiguration& scanner_configuration)
   : host_ip_(*scanner_configuration.hostIp())
   , host_udp_port_data_(scanner_configuration.hostUDPPortData())  // Write is deduced by the scanner
-  , master_device_settings_(scanner_configuration.diagnosticsEnabled())
-  , master_(scanner_configuration.scanRange(), MASTER_RESOLUTION)
+  , master_device_settings_(scanner_configuration.diagnosticsEnabled(), scanner_configuration.intensitiesEnabled())
+  , master_(scanner_configuration.scanRange(), scanner_configuration.scanResolution())
 {
 }
 

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -80,14 +80,15 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
    */
 
   const uint8_t device_enabled{ 0b00001000 };
-  const uint8_t intensity_enabled{ 0b00001000 };
+  const uint8_t intensity_enabled{ static_cast<uint8_t>(
+      msg.master_device_settings_.intensitiesEnabled() ? 0b00001000 : 0b00000000) };
   const uint8_t point_in_safety_enabled{ 0 };
   const uint8_t active_zone_set_enabled{ 0 };
   const uint8_t io_pin_enabled{ 0 };
   const uint8_t scan_counter_enabled{ 0b00001000 };
   const uint8_t speed_encoder_enabled{ 0 }; /**< 0000000bin disabled, 00001111bin enabled.*/
   const uint8_t diagnostics_enabled{ static_cast<uint8_t>(
-      msg.master_device_settings_.isDiagnosticsEnabled() ? 0b00001000 : 0b00000000) };
+      msg.master_device_settings_.diagnosticsEnabled() ? 0b00001000 : 0b00000000) };
 
   raw_processing::write(os, device_enabled);
   raw_processing::write(os, intensity_enabled);

--- a/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
@@ -34,6 +34,7 @@ namespace psen_scan_v2_standalone_test
 using namespace psen_scan_v2_standalone;
 
 static constexpr ScanRange DEFAULT_SCAN_RANGE{ util::TenthOfDegree(0), util::TenthOfDegree(60) };
+static constexpr util::TenthOfDegree DEFAULT_SCAN_RESOLUTION{ 2 };
 
 static double randDouble(double low, double high)
 {

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -105,6 +105,8 @@ ScannerConfiguration ScannerAPITests::generateScannerConfig(const std::string& h
                             .scannerDataPort(port_holder_.data_port_scanner)
                             .scannerControlPort(port_holder_.control_port_scanner)
                             .scanRange(DEFAULT_SCAN_RANGE)
+                            .scanResolution(DEFAULT_SCAN_RESOLUTION)
+                            .enableIntensities()
                             .enableFragmentedScans(fragmented);
   return config_builder.build();
 }

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -291,16 +291,22 @@ TEST_F(ScannerConfigurationTest, shouldReturnCorrectResolutionAfterConstruction)
   EXPECT_EQ(SCAN_RESOLUTION, sc.scanResolution());
 }
 
+TEST_F(ScannerConfigurationTest, shouldHaveCorrectResolutionOnDefault)
+{
+  const ScannerConfiguration sc{ createValidDefaultConfig() };
+  EXPECT_EQ(configuration::SCAN_RESOLUTION, sc.scanResolution());
+}
+
 TEST_F(ScannerConfigurationTest, shouldHaveEnabledIntensitiesAfterConstruction)
 {
   const ScannerConfiguration sc{ createValidConfig() };
-  EXPECT_EQ(true, sc.intensitiesEnabled());
+  EXPECT_TRUE(sc.intensitiesEnabled());
 }
 
 TEST_F(ScannerConfigurationTest, shouldHaveDisabledIntensitiesByDefault)
 {
   const ScannerConfiguration sc{ createValidDefaultConfig() };
-  EXPECT_EQ(false, sc.intensitiesEnabled());
+  EXPECT_FALSE(sc.intensitiesEnabled());
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -35,6 +35,7 @@ namespace psen_scan_v2_standalone_test
 static constexpr int MINIMAL_PORT_NUMBER{ std::numeric_limits<uint16_t>::min() };
 static constexpr int MAXIMAL_PORT_NUMBER{ std::numeric_limits<uint16_t>::max() };
 static constexpr ScanRange SCAN_RANGE{ util::TenthOfDegree(0), util::TenthOfDegree(2750) };
+static constexpr util::TenthOfDegree SCAN_RESOLUTION{ 2u };
 static const std::string VALID_IP{ "127.0.0.1" };
 static const std::string VALID_IP_OTHER{ "192.168.0.1" };
 static const std::string INVALID_IP{ "invalid_ip" };
@@ -55,7 +56,9 @@ static ScannerConfiguration createValidConfig()
       .scannerDataPort(MINIMAL_PORT_NUMBER + 1)
       .scannerControlPort(MINIMAL_PORT_NUMBER + 2)
       .scanRange(SCAN_RANGE)
+      .scanResolution(SCAN_RESOLUTION)
       .enableDiagnostics()
+      .enableIntensities()
       .build();
 }
 
@@ -69,7 +72,9 @@ static ScannerConfiguration createValidConfig(const std::string& host_ip)
       .scannerDataPort(MINIMAL_PORT_NUMBER + 1)
       .scannerControlPort(MINIMAL_PORT_NUMBER + 2)
       .scanRange(SCAN_RANGE)
+      .scanResolution(SCAN_RESOLUTION)
       .enableDiagnostics()
+      .enableIntensities()
       .enableFragmentedScans(true)
       .build();
 }

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -294,7 +294,7 @@ TEST_F(ScannerConfigurationTest, shouldReturnCorrectResolutionAfterConstruction)
 TEST_F(ScannerConfigurationTest, shouldHaveCorrectResolutionOnDefault)
 {
   const ScannerConfiguration sc{ createValidDefaultConfig() };
-  EXPECT_EQ(configuration::SCAN_RESOLUTION, sc.scanResolution());
+  EXPECT_EQ(configuration::SCAN_ANGLE_RESOLUTION, sc.scanResolution());
 }
 
 TEST_F(ScannerConfigurationTest, shouldHaveEnabledIntensitiesAfterConstruction)
@@ -303,18 +303,17 @@ TEST_F(ScannerConfigurationTest, shouldHaveEnabledIntensitiesAfterConstruction)
   EXPECT_TRUE(sc.intensitiesEnabled());
 }
 
-TEST_F(ScannerConfigurationTest, shouldHaveDisabledIntensitiesByDefault)
+TEST_F(ScannerConfigurationTest, shouldLoadIntensitiesFromConfigByDefault)
 {
   const ScannerConfiguration sc{ createValidDefaultConfig() };
-  EXPECT_FALSE(sc.intensitiesEnabled());
+  EXPECT_EQ(configuration::INTENSITIES, sc.intensitiesEnabled());
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithLowResolutionAndEnabledIntensitiesOnBuild)
 {
-  const ScannerConfiguration sc{ createValidDefaultConfig() };
-  sc.scanResolution(util::TenthOfDegree{ data_conversion_layer::degreeToTenthDegree(0.19) });
-  sc.enableIntensities();
-  EXPECT_THROW(sc.build(), std::invalid_argument);
+  ScannerConfigurationBuilder sb{};
+  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).enableIntensities().scanResolution(util::TenthOfDegree{ 1u });
+  EXPECT_THROW(sb.build(), std::invalid_argument);
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -319,15 +319,15 @@ TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithLowResolutionAndE
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingLowerLimit)
 {
   ScannerConfigurationBuilder sb{};
-  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).scanResolution(util::TenthOfDegree{ 0u });
-  EXPECT_THROW(sb.build(), std::invalid_argument);
+  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE);
+  EXPECT_THROW(sb.scanResolution(util::TenthOfDegree{ 0u }), std::invalid_argument);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingUpperLimit)
 {
   ScannerConfigurationBuilder sb{};
-  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).scanResolution(util::TenthOfDegree{ 101u });
-  EXPECT_THROW(sb.build(), std::invalid_argument);
+  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE);
+  EXPECT_THROW(sb.scanResolution(util::TenthOfDegree{ 101u }), std::invalid_argument);
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -288,8 +288,19 @@ TEST_F(ScannerConfigurationTest, shouldReturnSetHostIp)
 TEST_F(ScannerConfigurationTest, shouldReturnCorrectResolutionAfterConstruction)
 {
   const ScannerConfiguration sc{ createValidConfig() };
-
   EXPECT_EQ(SCAN_RESOLUTION, sc.scanResolution());
+}
+
+TEST_F(ScannerConfigurationTest, shouldHaveEnabledIntensitiesAfterConstruction)
+{
+  const ScannerConfiguration sc{ createValidConfig() };
+  EXPECT_EQ(true, sc.intensitiesEnabled());
+}
+
+TEST_F(ScannerConfigurationTest, shouldHaveDisabledIntensitiesByDefault)
+{
+  const ScannerConfiguration sc{ createValidDefaultConfig() };
+  EXPECT_EQ(false, sc.intensitiesEnabled());
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -285,6 +285,13 @@ TEST_F(ScannerConfigurationTest, shouldReturnSetHostIp)
   EXPECT_EQ(host_ip, sc.hostIp());
 }
 
+TEST_F(ScannerConfigurationTest, shouldReturnCorrectResolutionAfterConstruction)
+{
+  const ScannerConfiguration sc{ createValidConfig() };
+
+  EXPECT_EQ(SCAN_RESOLUTION, sc.scanResolution());
+}
+
 }  // namespace psen_scan_v2_standalone_test
 
 int main(int argc, char* argv[])

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -316,6 +316,20 @@ TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithLowResolutionAndE
   EXPECT_THROW(sb.build(), std::invalid_argument);
 }
 
+TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingLowerLimit)
+{
+  ScannerConfigurationBuilder sb{};
+  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).scanResolution(util::TenthOfDegree{ 0u });
+  EXPECT_THROW(sb.build(), std::invalid_argument);
+}
+
+TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingUpperLimit)
+{
+  ScannerConfigurationBuilder sb{};
+  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).scanResolution(util::TenthOfDegree{ 101u });
+  EXPECT_THROW(sb.build(), std::invalid_argument);
+}
+
 }  // namespace psen_scan_v2_standalone_test
 
 int main(int argc, char* argv[])

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -309,6 +309,14 @@ TEST_F(ScannerConfigurationTest, shouldHaveDisabledIntensitiesByDefault)
   EXPECT_FALSE(sc.intensitiesEnabled());
 }
 
+TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithLowResolutionAndEnabledIntensitiesOnBuild)
+{
+  const ScannerConfiguration sc{ createValidDefaultConfig() };
+  sc.scanResolution(util::TenthOfDegree{ data_conversion_layer::degreeToTenthDegree(0.19) });
+  sc.enableIntensities();
+  EXPECT_THROW(sc.build(), std::invalid_argument);
+}
+
 }  // namespace psen_scan_v2_standalone_test
 
 int main(int argc, char* argv[])

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -82,6 +82,8 @@ TEST_F(StartRequestTest, constructorTest)
                                                        .scannerDataPort(77)
                                                        .scannerControlPort(78)
                                                        .scanRange(scan_range)
+                                                       .scanResolution(util::TenthOfDegree(2u))
+                                                       .enableIntensities()
                                                        .build());
 
   auto data = serialize(sr, sequence_number);
@@ -149,6 +151,8 @@ static ScannerConfiguration createConfig(bool enable_diagnostics)
       .scannerIp("192.168.0.10")
       .scannerDataPort(2000)
       .scannerControlPort(3000)
+      .scanResolution(util::TenthOfDegree(2u))
+      .enableIntensities()
       .scanRange(ScanRange(util::TenthOfDegree(0), util::TenthOfDegree(2750)));
 
   if (enable_diagnostics)

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -91,10 +91,6 @@ TEST_F(StartRequestTest, constructorTest)
 
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::crc), (uint32_t)result.checksum()));
 
-  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::crc), 0xeb447fb));  // CRC - Fixed for now, Note:
-                                                                                   // Other byte order as in
-                                                                                   // wireshark
-
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::seq_number), (uint32_t)sequence_number));
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::reserved), (uint64_t)0));
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::opcode), (uint32_t)0x35));

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -82,8 +82,7 @@ TEST_F(StartRequestTest, constructorTest)
                                                        .scannerDataPort(77)
                                                        .scannerControlPort(78)
                                                        .scanRange(scan_range)
-                                                       .scanResolution(util::TenthOfDegree(2u))
-                                                       .enableIntensities()
+                                                       .scanResolution(util::TenthOfDegree(10))
                                                        .build());
 
   auto data = serialize(sr, sequence_number);
@@ -118,7 +117,7 @@ TEST_F(StartRequestTest, constructorTest)
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::udp_port), host_udp_port_data));
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::device_enabled), (uint8_t)0b00001000));
 
-  EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::intensities_enabled), 0b00001000));
+  EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::intensities_enabled), 0b00000000));
   EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::point_in_safety_enabled), 0));
   EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::active_zone_set_enabled), 0));
   EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::io_pin_enabled), 0));
@@ -129,7 +128,7 @@ TEST_F(StartRequestTest, constructorTest)
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_start_angle), scan_range.getStart().value()));
   EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_end_angle), scan_range.getEnd().value()));
   EXPECT_TRUE(DecodingEquals(
-      data, static_cast<size_t>(Offset::master_angle_resolution), data_conversion_layer::degreeToTenthDegree(0.2)));
+      data, static_cast<size_t>(Offset::master_angle_resolution), data_conversion_layer::degreeToTenthDegree(1.0)));
 
   EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_one_start_angle), 0));
   EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_one_end_angle), 0));


### PR DESCRIPTION
## Description

These changes add: 
 - the possibility to change the **resolution** of the scanner on startup (**default will change from 0.2 to 0.1** with this PR)
 - the possibility to disable/enable the **intensities** on startup (**default will change from true to false** with this PR)

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] Examples

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
  - when scan range changes are implemented as well
  - needs minor version change
- [x] ~Which dependent packages do have to be released simultaneously?~
