### PR TITLE
Feature/adapt standalone gtest version

### DIFF
--- a/standalone/CMakeLists.txt.in
+++ b/standalone/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
## Description

Related to https://github.com/google/googletest/commit/32f4f52d95dc99c35f51deed552a6ba700567f94

Without this GH actions would show

```CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

```
see https://github.com/PilzDE/psen_scan_v2/pull/201/checks?check_run_id=2762970697


### Depends on
- [x] #202 
