### PR TITLE
Enable hwtests with industrial_ci

### DIFF
--- a/test/hw_tests/config/big_resolution.yaml
+++ b/test/hw_tests/config/big_resolution.yaml
@@ -1,7 +1,5 @@
-host_ip: "auto"
-host_udp_port_data: 55115
+host_udp_port_data: 55001
 host_udp_port_control: 55116
-sensor_ip: "192.168.0.10"
 prefix: laser_1
 angle_start: deg(-137.4)
 angle_end: deg(137.4)

--- a/test/hw_tests/config/default.yaml
+++ b/test/hw_tests/config/default.yaml
@@ -1,7 +1,5 @@
-host_ip: "auto"
-host_udp_port_data: 55115
+host_udp_port_data: 55002
 host_udp_port_control: 55116
-sensor_ip: "192.168.0.10"
 prefix: "laser_1"
 angle_start: deg(-137.4)
 angle_end: deg(137.4)

--- a/test/hw_tests/config/subrange.yaml
+++ b/test/hw_tests/config/subrange.yaml
@@ -1,7 +1,5 @@
-host_ip: "auto"
-host_udp_port_data: 55115
+host_udp_port_data: 55003
 host_udp_port_control: 55116
-sensor_ip: "192.168.0.10"
 prefix: laser_1
 angle_start: deg(-100.)
 angle_end: deg(100.)

--- a/test/hw_tests/config/with_intensities.yaml
+++ b/test/hw_tests/config/with_intensities.yaml
@@ -1,7 +1,5 @@
-host_ip: "auto"
-host_udp_port_data: 55115
+host_udp_port_data: 55004
 host_udp_port_control: 55116
-sensor_ip: "192.168.0.10"
 prefix: laser_1
 angle_start: deg(-137.4)
 angle_end: deg(137.4)

--- a/test/hw_tests/hwtest_publish.test
+++ b/test/hw_tests/hwtest_publish.test
@@ -24,6 +24,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <arg name="sensor_ip" value="$(optenv SENSOR_IP 192.168.0.10)" />
     <arg name="host_ip" value="$(optenv HOST_IP auto)" />
     <arg name="rviz" value="False" />
+    <arg name="host_udp_port_data" value="55000"/>
   </include>
 
   <test name="publishtest"

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -20,6 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
   <node name="laser_scanner" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
     <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
+    <param name="sensor_ip" value="$(optenv SENSOR_IP 192.168.0.10)" />
+    <param name="host_ip" value="$(optenv HOST_IP auto)" />
   </node>
 
   <test test-name="scan_range" pkg="psen_scan_v2" type="hwtest_scan_range.py">


### PR DESCRIPTION
## Description

The tests need to read the environment variables SENSOR_IP and HOST_IP in order to be able using `industrial_ci` used by the hardware test.

Note so happy that ca624111d1f30d0665bcb7e56eda97a579284457 is needed by otherwise it seems that sometimes old messages from a previous test run are checked.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
- [x] Perform hardware tests
