### PR TITLE
Introduce bringup.launch for starting only the scanner node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Introduce bringup.launch for starting only the scanner node
 * Omit closing the data client before destruction. Fixes #212
 * Distance value at angle_end is now included in the scan range
 * Default scan range changed to [-137.4..137.4]deg at 0.1 deg resolution

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Set prefix for node name (same value as for tf frames)
 * Introduce bringup.launch for starting only the scanner node
 * Omit closing the data client before destruction. Fixes #212
 * Distance value at angle_end is now included in the scan range

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ IP-Address of safety laser scanner.
 ### Optional Parameters
 
 _prefix_ (_string_, default: "laser_1")<br/>
-Name of this scanner that can be changed to differentiate between multiple devices.
+Name of this scanner that can be changed to differentiate between multiple devices. By convention this is used both for the node name and the urdf description.
 
 _angle_start_ (_double_, default: -2.398 (= -137.4 deg))<br/>
 Start angle of measurement. (Radian)
@@ -103,7 +103,7 @@ _rviz_ (_bool_, default: true)<br/>
 Start a preconfigured rviz visualizing the scan data.
 
 ### Published Topics
-/laser_scanner/scan ([sensor_msgs/LaserScan][])<br/>
+/\<prefix\>_node/scan ([sensor_msgs/LaserScan][])<br/>
 
 * If _fragmented_scans_ is set to false (default) the driver will publish complete scan rounds from the PSENscan safety laser scanner as a single message.
 * If _fragmented_scans_ is enabled the driver will send the measurement data as soon as they arrive, instead of waiting for the scan round to be completed. This way the scan data is received sooner but is split into several sensor messages.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ roslaunch psen_scan_v2 psen_scan_v2.launch sensor_ip:=192.168.0.10
 ```
 This example configures the safety laser scanner at 192.168.0.10 to send it´s frames to 192.168.0.20:3050.
 
-The [tutorials](http://wiki.ros.org/psen_scan_v2/Tutorials/) describe how to create an application package with your own launch file, where
-you can easily adjust the configuration parameters.
+In order to create an application with your own launch file, you can include the `bringup.launch`, where you can easily adjust the configuration parameters. A more detailed explanation can be found in the [tutorials](http://wiki.ros.org/psen_scan_v2/Tutorials/).
 
 ### Parameters
 

--- a/config/config.rviz
+++ b/config/config.rviz
@@ -80,7 +80,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /laser_scanner/scan
+      Topic: /laser_1_node/scan
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: false

--- a/launch/bringup.launch
+++ b/launch/bringup.launch
@@ -20,7 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- IP-Address of Safety laser scanner -->
   <arg name="sensor_ip" default="192.168.0.10" />
 
-  <!-- Prefix i. e. name of the scanner (required to run multiple scanners) -->
+  <!-- Prefix i. e. name of the scanner (required to run multiple scanners)
+       By convention this should also be used as prefix for the urdf description. -->
   <arg name="prefix" default="laser_1" />
 
   <!-- Start angle of measurement in radian -->
@@ -48,7 +49,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- Set the following to true in order to publish scan data as soon as a UDP packet is ready, instead of waiting for a full scan -->
   <arg name="fragmented_scans" default="false" />
 
-  <node name="laser_scanner" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
+  <node name="$(arg prefix)_node" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
     <param name="sensor_ip" value="$(arg sensor_ip)" />
     <param name="prefix" value="$(arg prefix)" />
     <param name="angle_start" value="$(arg angle_start)" />

--- a/launch/bringup.launch
+++ b/launch/bringup.launch
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 
-<!-- Includes starting the scanner driver together with a robot model and preconfigured rviz. -->
+<!-- Use this launch-file for starting the scanner driver exclusively. -->
 <launch>
   <!-- IP-Address of Safety laser scanner -->
   <arg name="sensor_ip" default="192.168.0.10" />
@@ -48,30 +48,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- Set the following to true in order to publish scan data as soon as a UDP packet is ready, instead of waiting for a full scan -->
   <arg name="fragmented_scans" default="false" />
 
-  <!-- Start rviz -->
-  <arg name="rviz" default="true" />
+  <node name="laser_scanner" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
+    <param name="sensor_ip" value="$(arg sensor_ip)" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="angle_start" value="$(arg angle_start)" />
+    <param name="angle_end" value="$(arg angle_end)" />
+    <param name="intensities" value="$(arg intensities)" />
+    <param name="resolution" value="$(arg resolution)" />
+    <param name="host_ip" value="$(arg host_ip)" />
+    <param name="host_udp_port_data" value="$(arg host_udp_port_data)" />
+    <param name="host_udp_port_control" value="$(arg host_udp_port_control)" />
+    <param name="fragmented_scans" value="$(arg fragmented_scans)" />
+  </node>
 
-  <!-- Start scanner driver -->
-  <include file="$(find psen_scan_v2)/launch/bringup.launch">
-    <arg name="sensor_ip" value="$(arg sensor_ip)" />
-    <arg name="prefix" value="$(arg prefix)" />
-    <arg name="angle_start" value="$(arg angle_start)" />
-    <arg name="angle_end" value="$(arg angle_end)" />
-    <arg name="intensities" value="$(arg intensities)" />
-    <arg name="resolution" value="$(arg resolution)" />
-    <arg name="host_ip" value="$(arg host_ip)" />
-    <arg name="host_udp_port_data" value="$(arg host_udp_port_data)" />
-    <arg name="host_udp_port_control" value="$(arg host_udp_port_control)" />
-    <arg name="fragmented_scans" value="$(arg fragmented_scans)" />
-  </include>
-
-  <!-- Publish tf frames for the device -->
-  <param name="robot_description" command="$(find xacro)/xacro
-    '$(find psen_scan_v2)/urdf/example.urdf.xacro' prefix:=$(arg prefix)" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
-
-  <!-- Start rviz -->
-  <group if="$(arg rviz)">
-    <node name="rviz" type="rviz" pkg="rviz" args="-d $(find psen_scan_v2)/config/config.rviz" />
-  </group>
 </launch>

--- a/test/hw_tests/hwtest_publish.test
+++ b/test/hw_tests/hwtest_publish.test
@@ -32,7 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         pkg="rostest" type="publishtest">
     <rosparam>
       topics:
-        - name: laser_scanner/scan
+        - name: laser_1_node/scan
           timeout: 10
           negative: False
     </rosparam>

--- a/test/hw_tests/hwtest_scan_compare.cpp
+++ b/test/hw_tests/hwtest_scan_compare.cpp
@@ -46,7 +46,7 @@ std::map<int16_t, NormalDist> binsFromRosbag(std::string filepath)
   bag.open(filepath, rosbag::bagmode::Read);
 
   std::vector<std::string> topics;
-  topics.push_back(std::string("/laser_scanner/scan"));
+  topics.push_back(std::string("/laser_1_node/scan"));
 
   rosbag::View view(bag, rosbag::TopicQuery(topics));
 
@@ -106,7 +106,7 @@ TEST_F(ScanComparisonTests, simpleCompare)
   LaserScanValidator<ScanType> laser_scan_validator(bins_expected_);
   laser_scan_validator.reset();
   auto scan_subscriber = nh.subscribe<ScanType>(
-      "/laser_scanner/scan",
+      "/laser_1_node/scan",
       1000,
       boost::bind(&LaserScanValidator<ScanType>::scanCb, &laser_scan_validator, boost::placeholders::_1, window_size));
 

--- a/test/hw_tests/hwtest_scan_range.py
+++ b/test/hw_tests/hwtest_scan_range.py
@@ -20,7 +20,7 @@ class HwtestScanRange(unittest.TestCase):
         self.angle_start = rospy.get_param("~angle_start")
         self.angle_end = rospy.get_param("~angle_end")
         self.resolution = rospy.get_param("~resolution")
-        rospy.Subscriber("/laser_scanner/scan", LaserScan, self.callback)
+        rospy.Subscriber("/laser_1_node/scan", LaserScan, self.callback)
 
     def callback(self, msg):
         self.received_msgs.append(msg)

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <arg name="host_ip" value="$(optenv HOST_IP auto)" />
   </include>
 
-  <rosparam ns="laser_scanner" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
+  <rosparam ns="laser_1_node" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
 
   <test test-name="scan_range" pkg="psen_scan_v2" type="hwtest_scan_range.py">
     <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -18,11 +18,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <launch>
   <arg name="config" default="default.yaml" />
 
-  <node name="laser_scanner" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
-    <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
-    <param name="sensor_ip" value="$(optenv SENSOR_IP 192.168.0.10)" />
-    <param name="host_ip" value="$(optenv HOST_IP auto)" />
-  </node>
+  <include file="$(find psen_scan_v2)/launch/bringup.launch">
+    <arg name="sensor_ip" value="$(optenv SENSOR_IP 192.168.0.10)" />
+    <arg name="host_ip" value="$(optenv HOST_IP auto)" />
+  </include>
+
+  <rosparam ns="laser_scanner" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
 
   <test test-name="scan_range" pkg="psen_scan_v2" type="hwtest_scan_range.py">
     <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />

--- a/test/integration_tests/integrationtest_ros_scanner_launch.test
+++ b/test/integration_tests/integrationtest_ros_scanner_launch.test
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   </include>
 
   <test pkg="rostest" type="paramtest" name="paramtest_nonempty" test-name="paramtest_nonempty">
-    <param name="param_name_target" value="laser_scanner/sensor_ip" />
+    <param name="param_name_target" value="laser_1_node/sensor_ip" />
     <param name="test_duration" value="5.0" />
     <param name="wait_time" value="30.0" />
   </test>


### PR DESCRIPTION
## Description

These changes allow the system integrator to bringup the scanner from his custom launch file.
The tutorials are changed accordingly: https://github.com/PilzDE/pilz_tutorials/pull/29

To avoid confusion of the user the prefix of the node name is changed to match the prefix of the LaserScan-topic. In detail setting the prefix implies the following namings:
- node: `<prefix>_node`
- topic: `<prefix>_node/scan`
- tf frames: `<prefix>`, `<prefix>_mount_link`, `<prefix>_scan`

### Requirements
- [x] #216 merged


### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~~Public api function documentation~~
- [x] ~~Architecture documentation reflects actual code structure~~
- [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
- [x] ~~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [x] ~~Examples~~

### Review Checklist
- [x] ~~Soft- and hardware architecture (diagrams and description)~~
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
asap
- [x] Which dependent packages do have to be released simultaneously?
None

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests
