### PR TITLE
Send stop request before closing data connection.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
-* Appies hotfix for (`#212 <https://github.com/PilzDE/psen_scan_v2/issues/212>`_) ensuring stop request is shutdown
+* Applies hotfix for (`#212 <https://github.com/PilzDE/psen_scan_v2/issues/212>`_) ensuring stop request is shutdown
 * Distance value at angle_end is now included in the scan range
 * Default scan range changed to [-137.4..137.4]deg at 0.1 deg resolution
 * Add options for modifying resolution and enabling intensities

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Appies hotfix for (`#212 <https://github.com/PilzDE/psen_scan_v2/issues/212>`_) ensuring stop request is shutdown
 * Distance value at angle_end is now included in the scan range
 * Default scan range changed to [-137.4..137.4]deg at 0.1 deg resolution
 * Add options for modifying resolution and enabling intensities

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -131,8 +131,8 @@ template <class T>
 inline void ScannerProtocolDef::sendStopRequest(const T& event)
 {
   PSENSCAN_DEBUG("StateMachine", "Action: sendStopRequest");
-  args_->data_client_->close();
   args_->control_client_->write(data_conversion_layer::stop_request::serialize());
+  args_->data_client_->close();
 }
 
 inline void ScannerProtocolDef::handleMonitoringFrame(const scanner_events::RawMonitoringFrameReceived& event)


### PR DESCRIPTION
## Description

Hotfix for #212

Seems that

`args_->data_client_->close();` on occasion get stuck eventually getting a SIGTERM thus leaving the device running.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests
