### PR TITLE
Fix hwtest_scan_compare

### DIFF
--- a/test/hw_tests/hwtest_readme.md
+++ b/test/hw_tests/hwtest_readme.md
@@ -36,7 +36,7 @@ Then run
 ```
 rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main \
 CMAKE_ARGS="-DENABLE_HARDWARE_TESTING=ON" DOCKER_RUN_OPTS="--env \
-HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100 -p 55115:55115/udp -p 55116:55116/udp"
+HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100 -p 55000-55005:55000-55005/udp"
 ```
 note that you especially need to setup the `HOST_IP` to be the IP of your actually system
 in order to receive the data inside the docker container used by industrial_ci.
@@ -47,17 +47,17 @@ If you need to use a custom ROOT_CA and have a apt-proxy the command for running
 rosrun industrial_ci run_ci ROS_DISTRO=noetic ROS_REPO=main \
 CMAKE_ARGS="-DENABLE_HARDWARE_TESTING=ON" \
 DOCKER_RUN_OPTS="--env HOST_IP=192.168.0.122 --env SENSOR_IP=192.168.0.100 \
--p 55115:55115/udp -p 55116:55116/udp \
+-p 55000-55005:55000-55005/udp \
 -v /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro" \
 APT_PROXY=http://172.20.20.104:3142
 
 ```
 
-## Run `hwtest_scan_compare`
+## Hardware Test `hwtest_scan_compare`
 The `hwtest_scan_compare` compares scanner data to a set of prerecorded data in order to detect unwanted changes in the data itself (shifts, flips, ...).
 
 ### Build the test
-Same as above however **additionally** `-ENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN=ON` needs to be defined at compile time. At runtime the reference file needs to be set within the environment variable `HW_TEST_SCAN_COMPARE_TESTFILE`, for details see the instructions below.
+Same as above however **additionally** `-DENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN=ON` needs to be defined at compile time. At runtime the reference file needs to be set within the environment variable `HW_TEST_SCAN_COMPARE_TESTFILE`, for details see the instructions below.
 ### Setup the reference scan
 This step is only needed if the setup of the scanner or something within its environment changed.
 
@@ -78,4 +78,14 @@ To run the hardware tests execute
 ```
 export HW_TEST_SCAN_COMPARE_TESTFILE=<path/to/reference/file.bag>
 rostest psen_scan_v2 hwtest_scan_compare.test
+```
+
+### Build and run using `industrial_ci`
+In addition to the arguments displayed above, you need to make the reference scan available to the docker container. Firstly, create a folder containing the bag-file with the reference scan. Then add the following to the `DOCKER_RUN_OPTS`:
+```
+-v <your/desired/path/to/folder>:/testfiles --env HW_TEST_SCAN_COMPARE_TESTFILE=/testfiles/<file.bag>
+```
+and the following to the `CMAKE_ARGS` option:
+```
+-DENABLE_HARDWARE_TESTING_WITH_REFERENCE_SCAN=ON
 ```

--- a/test/hw_tests/hwtest_scan_compare.test
+++ b/test/hw_tests/hwtest_scan_compare.test
@@ -18,12 +18,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <launch>
   <arg name="test_duration" default="10"/>
 
-  <include file="$(find psen_scan_v2)/launch/psen_scan_v2.launch">
+  <include file="$(find psen_scan_v2)/launch/bringup.launch">
     <arg name="angle_start" value="-1.2" />
     <arg name="angle_end" value="1.2" />
     <arg name="sensor_ip" value="$(optenv SENSOR_IP 192.168.0.10)" />
     <arg name="host_ip" value="$(optenv HOST_IP auto)" />
-    <arg name="rviz" value="False" />
+    <arg name="host_udp_port_data" value="55005" />
   </include>
 
   <test test-name="scan_compare" pkg="psen_scan_v2" type="hwtest_scan_compare" time-limit="$(eval test_duration + 10)">


### PR DESCRIPTION
## Description

These changes make `hwtest_scan_compare` run in industrial_ci. Fixes #205 

Fix hwtest_scan_compare:
* Include bringup.launch
* Set unique udp port for data connection
* Only start laserscan validation when connected on topic
* Omit using SetUpTestSuite()
Due to google/googletest#247
Can be reverted once googletest version is at least 1.11.0

Update hwtest_readme.md:
* Update forwarded udp ports
* Add description for running test with reference scan using industrial_ci

### Things to add, update or check by the maintainers before this PR can be merged.

- [ ] ~Public api function documentation~
- [ ] ~Architecture documentation reflects actual code structure~
- [ ] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [ ] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [ ] ~CHANGELOG.rst updated~
- [x] Copyright headers
- [ ] ~Examples~

### Review Checklist
- [ ] Soft- and hardware architecture (diagrams and description)
- [ ] Test review (test plan and individual test cases)
- [ ] Documentation describes purpose of file(s) and responsibilities
- [ ] Code (coding rules, style guide)

### Release planning (please answer)
- [ ] ~When is the new feature released?~
- [ ] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests
