### PR TITLE
Apply convention node name equals tf prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package psen_scan_v2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Apply tf prefix equals node name
+
 0.3.0 (2021-06-29)
 ------------------
 * Set prefix for node name (same value as for tf frames)

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ IP-Address of safety laser scanner.
 
 ### Optional Parameters
 
-_prefix_ (_string_, default: "laser_1")<br/>
-Name of this scanner that can be changed to differentiate between multiple devices. By convention this is used both for the node name and the urdf description.
+_name_ (_string_, default: "laser_1")<br/>
+Name of this scanner that can be changed to differentiate between multiple devices. By convention this is also used as tf prefix.
 
 _angle_start_ (_double_, default: -2.398 (= -137.4 deg))<br/>
 Start angle of measurement. (Radian)
@@ -103,7 +103,7 @@ _rviz_ (_bool_, default: true)<br/>
 Start a preconfigured rviz visualizing the scan data.
 
 ### Published Topics
-/\<prefix\>_node/scan ([sensor_msgs/LaserScan][])<br/>
+/\<name\>/scan ([sensor_msgs/LaserScan][])<br/>
 
 * If _fragmented_scans_ is set to false (default) the driver will publish complete scan rounds from the PSENscan safety laser scanner as a single message.
 * If _fragmented_scans_ is enabled the driver will send the measurement data as soon as they arrive, instead of waiting for the scan round to be completed. This way the scan data is received sooner but is split into several sensor messages.
@@ -114,7 +114,7 @@ Start a preconfigured rviz visualizing the scan data.
 
 ### TF Frames
 The location of the TF frames is shown in the image below.
-These names are defined by the aforementioned launchfile parameter `prefix`.
+These names are defined by the aforementioned launchfile parameter `name`.
 Changing them is necessary for instance when running multiple scanners.
 <p align="center">
 <img src="img/frames.png" width="800px" alt="PILZ safety laser scanner frames" title="frames">

--- a/config/config.rviz
+++ b/config/config.rviz
@@ -80,7 +80,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /laser_1_node/scan
+      Topic: /laser_1/scan
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: false

--- a/launch/bringup.launch
+++ b/launch/bringup.launch
@@ -20,9 +20,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- IP-Address of Safety laser scanner -->
   <arg name="sensor_ip" default="192.168.0.10" />
 
-  <!-- Prefix i. e. name of the scanner (required to run multiple scanners)
+  <!-- Name of the scanner (required to run multiple scanners)
        By convention this should also be used as prefix for the urdf description. -->
-  <arg name="prefix" default="laser_1" />
+  <arg name="name" default="laser_1" />
 
   <!-- Start angle of measurement in radian -->
   <arg name="angle_start" default="$(eval radians(-137.4))" />
@@ -49,9 +49,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- Set the following to true in order to publish scan data as soon as a UDP packet is ready, instead of waiting for a full scan -->
   <arg name="fragmented_scans" default="false" />
 
-  <node name="$(arg prefix)_node" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
+  <node name="$(arg name)" type="psen_scan_v2_node" pkg="psen_scan_v2" output="screen" required="true">
     <param name="sensor_ip" value="$(arg sensor_ip)" />
-    <param name="prefix" value="$(arg prefix)" />
+    <param name="name" value="$(arg name)" />
     <param name="angle_start" value="$(arg angle_start)" />
     <param name="angle_end" value="$(arg angle_end)" />
     <param name="intensities" value="$(arg intensities)" />

--- a/launch/psen_scan_v2.launch
+++ b/launch/psen_scan_v2.launch
@@ -20,8 +20,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- IP-Address of Safety laser scanner -->
   <arg name="sensor_ip" default="192.168.0.10" />
 
-  <!-- Prefix i. e. name of the scanner (required to run multiple scanners) -->
-  <arg name="prefix" default="laser_1" />
+  <!-- Name of the scanner (required to run multiple scanners) -->
+  <arg name="name" default="laser_1" />
 
   <!-- Start angle of measurement in radian -->
   <arg name="angle_start" default="$(eval radians(-137.4))" />
@@ -54,7 +54,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <!-- Start scanner driver -->
   <include file="$(find psen_scan_v2)/launch/bringup.launch">
     <arg name="sensor_ip" value="$(arg sensor_ip)" />
-    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="name" value="$(arg name)" />
     <arg name="angle_start" value="$(arg angle_start)" />
     <arg name="angle_end" value="$(arg angle_end)" />
     <arg name="intensities" value="$(arg intensities)" />
@@ -67,7 +67,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
   <!-- Publish tf frames for the device -->
   <param name="robot_description" command="$(find xacro)/xacro
-    '$(find psen_scan_v2)/urdf/example.urdf.xacro' prefix:=$(arg prefix)" />
+    '$(find psen_scan_v2)/urdf/example.urdf.xacro' prefix:=$(arg name)" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
   <!-- Start rviz -->

--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -42,7 +42,7 @@ const std::string PARAM_HOST_IP{ "host_ip" };
 const std::string PARAM_HOST_DATA_PORT{ "host_udp_port_data" };
 const std::string PARAM_HOST_CONTROL_PORT{ "host_udp_port_control" };
 const std::string PARAM_SCANNER_IP{ "sensor_ip" };
-const std::string PARAM_PREFIX{ "prefix" };
+const std::string PARAM_PREFIX{ "name" };
 const std::string PARAM_ANGLE_START{ "angle_start" };
 const std::string PARAM_ANGLE_END{ "angle_end" };
 const std::string PARAM_X_AXIS_ROTATION{ "x_axis_rotation" };

--- a/test/hw_tests/config/big_resolution.yaml
+++ b/test/hw_tests/config/big_resolution.yaml
@@ -1,6 +1,6 @@
 host_udp_port_data: 55001
 host_udp_port_control: 55116
-prefix: laser_1
+name: laser_1
 angle_start: deg(-137.4)
 angle_end: deg(137.4)
 resolution: deg(1.0)

--- a/test/hw_tests/config/default.yaml
+++ b/test/hw_tests/config/default.yaml
@@ -1,6 +1,6 @@
 host_udp_port_data: 55002
 host_udp_port_control: 55116
-prefix: "laser_1"
+name: "laser_1"
 angle_start: deg(-137.4)
 angle_end: deg(137.4)
 resolution: deg(0.1)

--- a/test/hw_tests/config/subrange.yaml
+++ b/test/hw_tests/config/subrange.yaml
@@ -1,6 +1,6 @@
 host_udp_port_data: 55003
 host_udp_port_control: 55116
-prefix: laser_1
+name: laser_1
 angle_start: deg(-100.)
 angle_end: deg(100.)
 resolution: deg(0.1)

--- a/test/hw_tests/config/with_intensities.yaml
+++ b/test/hw_tests/config/with_intensities.yaml
@@ -1,6 +1,6 @@
 host_udp_port_data: 55004
 host_udp_port_control: 55116
-prefix: laser_1
+name: laser_1
 angle_start: deg(-137.4)
 angle_end: deg(137.4)
 resolution: deg(0.2)

--- a/test/hw_tests/hwtest_publish.test
+++ b/test/hw_tests/hwtest_publish.test
@@ -29,7 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         pkg="rostest" type="publishtest">
     <rosparam>
       topics:
-        - name: laser_1_node/scan
+        - name: laser_1/scan
           timeout: 10
           negative: False
     </rosparam>

--- a/test/hw_tests/hwtest_scan_compare.cpp
+++ b/test/hw_tests/hwtest_scan_compare.cpp
@@ -46,7 +46,7 @@ std::map<int16_t, NormalDist> binsFromRosbag(std::string filepath)
   bag.open(filepath, rosbag::bagmode::Read);
 
   std::vector<std::string> topics;
-  topics.push_back(std::string("/laser_1_node/scan"));
+  topics.push_back(std::string("/laser_1/scan"));
 
   rosbag::View view(bag, rosbag::TopicQuery(topics));
 
@@ -106,7 +106,7 @@ TEST_F(ScanComparisonTests, simpleCompare)
   LaserScanValidator<ScanType> laser_scan_validator(bins_expected_);
   laser_scan_validator.reset();
   auto scan_subscriber = nh.subscribe<ScanType>(
-      "/laser_1_node/scan",
+      "/laser_1/scan",
       1000,
       boost::bind(&LaserScanValidator<ScanType>::scanCb, &laser_scan_validator, boost::placeholders::_1, window_size));
 

--- a/test/hw_tests/hwtest_scan_range.py
+++ b/test/hw_tests/hwtest_scan_range.py
@@ -20,7 +20,7 @@ class HwtestScanRange(unittest.TestCase):
         self.angle_start = rospy.get_param("~angle_start")
         self.angle_end = rospy.get_param("~angle_end")
         self.resolution = rospy.get_param("~resolution")
-        rospy.Subscriber("/laser_1_node/scan", LaserScan, self.callback)
+        rospy.Subscriber("/laser_1/scan", LaserScan, self.callback)
 
     def callback(self, msg):
         self.received_msgs.append(msg)

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -23,7 +23,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     <arg name="host_ip" value="$(optenv HOST_IP auto)" />
   </include>
 
-  <rosparam ns="laser_1_node" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
+  <rosparam ns="laser_1" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
 
   <test test-name="scan_range" pkg="psen_scan_v2" type="hwtest_scan_range.py">
     <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />

--- a/test/integration_tests/integrationtest_ros_scanner_launch.test
+++ b/test/integration_tests/integrationtest_ros_scanner_launch.test
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   </include>
 
   <test pkg="rostest" type="paramtest" name="paramtest_nonempty" test-name="paramtest_nonempty">
-    <param name="param_name_target" value="laser_1_node/sensor_ip" />
+    <param name="param_name_target" value="laser_1/sensor_ip" />
     <param name="test_duration" value="5.0" />
     <param name="wait_time" value="30.0" />
   </test>


### PR DESCRIPTION
## Description

These changes fix the naming convention introduced in c5f8f385a901cfc2b28b8a34c83ca561a1ef9c36 such that the node name equals the tf prefix.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
- [ ] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [x] Examples

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] ~Code (coding rules, style guide)~

### Release planning (please answer)
- [x] When is the new feature released? a.s.a.p.
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests