### PR TITLE
Refactor laserscan comparison

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Forthcoming
 * Calculate timestamp as the time of the first ray (udp communication time is neglected)
 * API: Add timestamp (nanoseconds since epoch) to LaserScan
 * API: Add scan counter to LaserScan
+* API: remove LaserScan equality operator
 * Contributors: Pilz GmbH and Co. KG
 
 0.3.1 (2021-07-21)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(unittest_laserscan
     ${catkin_LIBRARIES}
+    fmt::fmt
   )
 
   catkin_add_gtest(unittest_laserscan_conversions

--- a/standalone/include/psen_scan_v2_standalone/laserscan.h
+++ b/standalone/include/psen_scan_v2_standalone/laserscan.h
@@ -16,8 +16,9 @@
 #ifndef PSEN_SCAN_V2_STANDALONE_LASERSCAN_H
 #define PSEN_SCAN_V2_STANDALONE_LASERSCAN_H
 
-#include <vector>
 #include <cstdint>
+#include <ostream>
+#include <vector>
 
 #include "psen_scan_v2_standalone/util/tenth_of_degree.h"
 
@@ -66,8 +67,6 @@ public:
   const IntensityData& getIntensities() const;
   void setIntensities(const IntensityData&);
 
-  bool operator==(const LaserScan& scan) const;
-
 private:
   //! Measurement data of the laserscan (in Millimeters).
   MeasurementData measurements_;
@@ -84,6 +83,8 @@ private:
   //! Time of the first ray in this scan round (or fragment if fragmented_scans is enabled).
   const int64_t timestamp_;
 };
+
+std::ostream& operator<<(std::ostream& os, const LaserScan& scan);
 
 }  // namespace psen_scan_v2_standalone
 

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -14,10 +14,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <algorithm>
+#include <ostream>
 #include <stdexcept>
+
+#include <fmt/format.h>
 
 #include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
 #include "psen_scan_v2_standalone/laserscan.h"
+#include "psen_scan_v2_standalone/util/format_range.h"
 
 namespace psen_scan_v2_standalone
 {
@@ -100,11 +104,18 @@ void LaserScan::setIntensities(const IntensityData& intensities)
   intensities_ = intensities;
 }
 
-bool LaserScan::operator==(const LaserScan& scan) const
+std::ostream& operator<<(std::ostream& os, const LaserScan& scan)
 {
-  return ((max_scan_angle_ == scan.max_scan_angle_) && (min_scan_angle_ == scan.min_scan_angle_) &&
-          (resolution_ == scan.resolution_) && (measurements_.size() == scan.measurements_.size()) &&
-          std::equal(measurements_.begin(), measurements_.end(), scan.measurements_.begin()));
+  os << fmt::format("LaserScan(timestamp = {} nsec, scanCounter = {}, minScanAngle = {} deg, maxScanAngle = {} deg, "
+                    "resolution = {} deg, measurements = {}, intensities = {})",
+                    scan.getTimestamp(),
+                    scan.getScanCounter(),
+                    scan.getMinScanAngle().value() / 10.,
+                    scan.getMaxScanAngle().value() / 10.,
+                    scan.getScanResolution().value() / 10.,
+                    util::formatRange(scan.getMeasurements()),
+                    util::formatRange(scan.getIntensities()));
+  return os;
 }
 
 }  // namespace psen_scan_v2_standalone

--- a/standalone/test/unit_tests/api/unittest_laserscan.cpp
+++ b/standalone/test/unit_tests/api/unittest_laserscan.cpp
@@ -18,6 +18,9 @@
 
 #include <gtest/gtest.h>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "psen_scan_v2_standalone/laserscan.h"
 
 using namespace psen_scan_v2_standalone;
@@ -142,6 +145,27 @@ TEST(LaserScanTest, testGetTimestamp)
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
   EXPECT_EQ(DEFAULT_TIMESTAMP, laser_scan->getTimestamp());
+}
+
+TEST(LaserScanTest, testPrintMessageSuccess)
+{
+  LaserScanBuilder laser_scan_builder;
+  std::unique_ptr<LaserScan> laser_scan;
+  ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
+
+  laser_scan->setMeasurements({ 45.0, 44.0, 43.0, 42.0 });
+
+// For compatibility with different ubuntu versions (resp. fmt), we need to take account of changes in
+// the default formatting of floating point numbers
+#if (FMT_VERSION >= 60000 && FMT_VERSION < 70100)
+  EXPECT_EQ(fmt::format("{}", *laser_scan),
+            "LaserScan(timestamp = 1 nsec, scanCounter = 1, minScanAngle = 0.1 deg, maxScanAngle = 0.2 deg, resolution "
+            "= 0.1 deg, measurements = {45.0, 44.0, 43.0, 42.0}, intensities = {})");
+#else
+  EXPECT_EQ(fmt::format("{}", *laser_scan),
+            "LaserScan(timestamp = 1 nsec, scanCounter = 1, minScanAngle = 0.1 deg, maxScanAngle = 0.2 deg, resolution "
+            "= 0.1 deg, measurements = {45, 44, 43, 42}, intensities = {})");
+#endif
 }
 
 }  // namespace psen_scan_v2_standalone_test


### PR DESCRIPTION
## Description

These changes avoid confusion about the LaserScan equality operator.

It is not clear, if this operator should compare the timestamps and if it really should check measurements/intensities (double values!) for equality. So we remove it. In our code it is only used in tests where it can by replaced by a more descriptive matcher.

note: My first attempt of using Pointwise(DoubleEq(), ...) as matcher did not work with the googletest version on bionic.

Changes in detail:
- Refactor laserscan comparison
- Add ostream operator for better output in case of test failure

- [x] Rebase after #223 

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [ ] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [ ] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [ ] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [ ] ~Examples~

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [ ] ~When is the new feature released?~
- [ ] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
- [ ] Perform hardware tests
