### PR TITLE
Enable output on failure for standalone ci jobs

### DIFF
--- a/.github/workflows/ci_action_standalone.yml
+++ b/.github/workflows/ci_action_standalone.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   BUILD_TYPE: "Release"
+  CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
   build:

--- a/.github/workflows/ci_action_win_standalone.yml
+++ b/.github/workflows/ci_action_win_standalone.yml
@@ -6,6 +6,7 @@ env:
   BUILD_TYPE: "Release"
   BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
   BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
+  CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
   build:


### PR DESCRIPTION
Here is an example output with a test failure:

https://github.com/martiniil/psen_scan_v2/runs/3408852133