### PR TITLE
Make release build the default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
 add_compile_options(-Werror)
 
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   rosconsole_bridge
   roscpp

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -30,6 +30,10 @@ endif (WIN32)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 ## System dependencies are found with CMake's conventions
 find_package(Boost 1.69) ## Boost::system is header-only since 1.69
 if(Boost_FOUND)

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -37,7 +37,6 @@ namespace data_conversion_layer
 {
 namespace start_request
 {
-static constexpr std::size_t SIZE{ 58 };  // See protocol description
 static constexpr uint64_t RESERVED{ 0 };
 
 static const uint32_t OPCODE{ 0x35 };
@@ -135,7 +134,7 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
   std::string raw_data_with_crc_str(os_crc.str() + os.str());
   data_conversion_layer::RawData raw_data_with_crc{ raw_data_with_crc_str.cbegin(), raw_data_with_crc_str.cend() };
 
-  assert(raw_data_with_crc.size() == SIZE && "Message data of start request has not the expected size");
+  assert(raw_data_with_crc.size() == 58 && "Message data of start request has not the size expceted by protocol");
 
   return raw_data_with_crc;
 }


### PR DESCRIPTION
## Description

This PR changes the default build type to be a release build.
This way the tests gets executed in release build which is prefarable specially for hardware tests.

### Things to add, update or check by the maintainers before this PR can be merged.
- [ ] ~Public api function documentation~
- [ ] ~Architecture documentation reflects actual code structure~
- [ ] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [ ] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [ ] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [ ] CHANGELOG.rst updated
- [ ] ~Copyright headers~
- [ ] ~Examples~

### Review Checklist
- [ ] ~Soft- and hardware architecture (diagrams and description)~
- [ ] ~Test review (test plan and individual test cases)~
- [ ] ~Documentation describes purpose of file(s) and responsibilities~
- [ ] Code (coding rules, style guide)

### Release planning (please answer)
- [ ] When is the new feature released?
- [ ] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
- [ ] Perform hardware tests
