### PR TITLE
Remove unneccessary fmt::format

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -56,14 +56,14 @@ inline ScannerProtocolDef::ScannerProtocolDef(const ScannerConfiguration config,
   template <class Event, class FSM>\
   void ScannerProtocolDef::state_name::on_entry(Event const&, FSM& fsm)\
   {\
-    PSENSCAN_DEBUG("StateMachine", fmt::format("Entering state: {}", #state_name));\
+    PSENSCAN_DEBUG("StateMachine", "Entering state: " #state_name);\
   }\
 
 #define DEFAULT_ON_EXIT_IMPL(state_name)\
   template <class Event, class FSM>\
   void ScannerProtocolDef::state_name::on_exit(Event const&, FSM& fsm)\
   {\
-    PSENSCAN_DEBUG("StateMachine", fmt::format("Exiting state: {}", #state_name));\
+    PSENSCAN_DEBUG("StateMachine", "Exiting state: " #state_name);\
   }
 
 #define DEFAULT_STATE_IMPL(state_name)\
@@ -79,7 +79,7 @@ DEFAULT_ON_ENTRY_IMPL(Idle)
 template <class Event, class FSM>
 void ScannerProtocolDef::Idle::on_exit(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Exiting state: {}", "Idle"));
+  PSENSCAN_DEBUG("StateMachine", "Exiting state: Idle");
   fsm.control_client_.startAsyncReceiving();
   fsm.data_client_.startAsyncReceiving();
 }
@@ -87,7 +87,7 @@ void ScannerProtocolDef::Idle::on_exit(Event const&, FSM& fsm)
 template <class Event, class FSM>
 void ScannerProtocolDef::WaitForStartReply::on_entry(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Entering state: {}", "WaitForStartReply"));
+  PSENSCAN_DEBUG("StateMachine", "Entering state: WaitForStartReply");
   // Start watchdog...
   fsm.start_reply_watchdog_ = fsm.watchdog_factory_.create(WATCHDOG_TIMEOUT, fsm.start_timeout_callback_);
 }
@@ -95,7 +95,7 @@ void ScannerProtocolDef::WaitForStartReply::on_entry(Event const&, FSM& fsm)
 template <class Event, class FSM>
 void ScannerProtocolDef::WaitForStartReply::on_exit(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Exiting state: {}", "WaitForStartReply"));
+  PSENSCAN_DEBUG("StateMachine", "Exiting state: {}", "WaitForStartReply");
   // Stops the watchdog by resetting the pointer
   fsm.start_reply_watchdog_.reset();
 }
@@ -103,7 +103,7 @@ void ScannerProtocolDef::WaitForStartReply::on_exit(Event const&, FSM& fsm)
 template <class Event, class FSM>
 void ScannerProtocolDef::WaitForMonitoringFrame::on_entry(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Entering state: {}", "WaitForMonitoringFrame"));
+  PSENSCAN_DEBUG("StateMachine", "Entering state: WaitForMonitoringFrame");
   fsm.scan_buffer_.reset();
   // Start watchdog...
   fsm.monitoring_frame_watchdog_ =
@@ -114,7 +114,7 @@ void ScannerProtocolDef::WaitForMonitoringFrame::on_entry(Event const&, FSM& fsm
 template <class Event, class FSM>
 void ScannerProtocolDef::WaitForMonitoringFrame::on_exit(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Exiting state: {}", "WaitForMonitoringFrame"));
+  PSENSCAN_DEBUG("StateMachine", "Exiting state: WaitForMonitoringFrame");
   // Stops the watchdog by resetting the pointer
   fsm.monitoring_frame_watchdog_.reset();
 }
@@ -122,7 +122,7 @@ void ScannerProtocolDef::WaitForMonitoringFrame::on_exit(Event const&, FSM& fsm)
 template <class Event, class FSM>
 void ScannerProtocolDef::Stopped::on_entry(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", fmt::format("Entering state: {}", "Stopped"));
+  PSENSCAN_DEBUG("StateMachine", "Entering state: Stopped");
   fsm.scanner_stopped_callback_();
 }
 

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -95,7 +95,7 @@ void ScannerProtocolDef::WaitForStartReply::on_entry(Event const&, FSM& fsm)
 template <class Event, class FSM>
 void ScannerProtocolDef::WaitForStartReply::on_exit(Event const&, FSM& fsm)
 {
-  PSENSCAN_DEBUG("StateMachine", "Exiting state: {}", "WaitForStartReply");
+  PSENSCAN_DEBUG("StateMachine", "Exiting state: WaitForStartReply");
   // Stops the watchdog by resetting the pointer
   fsm.start_reply_watchdog_.reset();
 }


### PR DESCRIPTION
## Description

Removes unnecessary calls to `fmt::format`

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots]~(https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] ~Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))~
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
