### PR TITLE
Fix scanner deconstruction

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
+++ b/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
@@ -135,6 +135,14 @@ public:
   void write(const data_conversion_layer::RawData& data);
 
   /**
+   * @brief Stops the underlying io_service so that no messages are received anymore.
+   *
+   * Note: In contrary to close() this is non-blocking but note that after calling stop()
+   * calls to the msg_callback are still possible due to pending messages.
+   */
+  void stop();
+
+  /**
    * @brief Closes the UDP connection and stops all pending asynchronous operation.
    */
   void close();
@@ -199,6 +207,11 @@ inline communication_layer::UdpClientImpl::UdpClientImpl(const NewMessageCallbac
 
   assert(!io_service_thread_.joinable() && "io_service_thread_ is joinable!");
   io_service_thread_ = std::thread([this]() { io_service_.run(); });
+}
+
+inline void UdpClientImpl::stop()
+{
+  io_service_.stop();
 }
 
 inline void UdpClientImpl::close()

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -159,6 +159,7 @@ template <class T>
 inline void ScannerProtocolDef::sendStopRequest(const T& event)
 {
   PSENSCAN_DEBUG("StateMachine", "Action: sendStopRequest");
+  data_client_.stop();
   control_client_.write(data_conversion_layer::stop_request::serialize());
 }
 

--- a/standalone/src/scanner_v2.cpp
+++ b/standalone/src/scanner_v2.cpp
@@ -62,9 +62,6 @@ ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScan
 ScannerV2::~ScannerV2()
 {
   PSENSCAN_DEBUG("Scanner", "Destruction called.");
-
-  const std::lock_guard<std::mutex> lock(member_mutex_);
-  sm_->stop();
 }
 
 std::future<void> ScannerV2::start()

--- a/standalone/src/scanner_v2.cpp
+++ b/standalone/src/scanner_v2.cpp
@@ -62,6 +62,9 @@ ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScan
 ScannerV2::~ScannerV2()
 {
   PSENSCAN_DEBUG("Scanner", "Destruction called.");
+
+  const std::lock_guard<std::mutex> lock(member_mutex_);
+  sm_->stop();
 }
 
 std::future<void> ScannerV2::start()

--- a/test/include/psen_scan_v2/laserscan_validator.h
+++ b/test/include/psen_scan_v2/laserscan_validator.h
@@ -163,7 +163,7 @@ public:
         auto dist_actual = bin_actual.second;
         auto dist_expected = bin_expected->second;
         auto distance = bhattacharyya_distance(dist_actual, dist_expected);
-        if (distance > 10.)
+        if (distance > 20.)
         {
           error_string +=
               fmt::format("On {:+.1f} deg  expected: {} actual: {} | dist: {:.1f}, dmean: {:.3f}, dstdev: {:.3f}\n",


### PR DESCRIPTION
## Description

These changes Fix #241 by changing the scanner deconstruction.

These changes solve the problem since:

- `stop()` on the state machine does not prevent further `process_event` thus it is better to transition into the defined `Stop`-State. I.e. we (currently) always require a call to `ScannerV2::stop()`. To avoid receiving more messages the `io_service` needed to be stopped(). It seems that going into destruction while receiving messages which are redirected to `handleReceiveMessage` is a bad idea...
- Inside the tests the member order the mock is put at the end so that is gets destroyed first. This in combination with the above seems to stabilize the test.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests

</details>
