### PR TITLE
Fix test ports clash

### DIFF
--- a/standalone/test/unit_tests/communication_layer/unittest_udp_client.cpp
+++ b/standalone/test/unit_tests/communication_layer/unittest_udp_client.cpp
@@ -28,8 +28,8 @@
 
 namespace psen_scan_v2_standalone_test
 {
-static constexpr unsigned short HOST_UDP_READ_PORT{ 45001 };
-static constexpr unsigned short UDP_MOCK_SEND_PORT{ HOST_UDP_READ_PORT + 1 };
+static constexpr unsigned short HOST_UDP_READ_PORT{ 40001 };
+static constexpr unsigned short UDP_MOCK_SEND_PORT{ HOST_UDP_READ_PORT + 100 };
 
 static const std::string UDP_MOCK_IP_ADDRESS{ "127.0.0.1" };
 
@@ -85,9 +85,9 @@ TEST(UdpClientTests, testInvalidErrorCallback)
   EXPECT_THROW(psen_scan_v2_standalone::communication_layer::UdpClientImpl reader(
                    std::bind(&CallbackHandler::handleNewData, &handler, _1, _2, _3),
                    nullptr,
-                   HOST_UDP_READ_PORT,
+                   HOST_UDP_READ_PORT + 1,
                    boost::asio::ip::make_address_v4(UDP_MOCK_IP_ADDRESS.c_str()).to_uint(),
-                   UDP_MOCK_SEND_PORT),
+                   UDP_MOCK_SEND_PORT + 1),
                std::invalid_argument);
 #elif BOOST_VERSION >= 106900
   EXPECT_THROW(psen_scan_v2_standalone::communication_layer::UdpClientImpl reader(


### PR DESCRIPTION
## Description

Fixes a clash in the port range of `unittest_udp_client` and `integrationtest_scanner_api`. 

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
