### PR TITLE
Minor improvement of TenthOfDegree

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/util/tenth_of_degree.h
+++ b/standalone/include/psen_scan_v2_standalone/util/tenth_of_degree.h
@@ -93,6 +93,11 @@ public:
     return *this;
   }
 
+  constexpr TenthOfDegree operator/(const TenthOfDegree& rhs) const
+  {
+    return TenthOfDegree(value() / rhs.value());
+  }
+
   constexpr TenthOfDegree operator+(const TenthOfDegree& rhs) const
   {
     return TenthOfDegree(value() + rhs.value());
@@ -102,6 +107,11 @@ public:
   {
     tenth_of_degree_ = value() + rhs.value();
     return *this;
+  }
+
+  constexpr TenthOfDegree operator-(const TenthOfDegree& rhs) const
+  {
+    return TenthOfDegree(value() - rhs.value());
   }
 
   TenthOfDegree& operator-(const TenthOfDegree& rhs)
@@ -138,15 +148,6 @@ public:
   constexpr bool operator<(const TenthOfDegree& rhs) const
   {
     return value() < rhs.value();
-  }
-
-  constexpr operator uint16_t() const
-  {
-    if (value() < 0)
-    {
-      throw std::underflow_error("Can only use values over zero as unsigned int.");
-    }
-    return value();
   }
 
 private:

--- a/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
@@ -77,7 +77,7 @@ createValidMonitoringFrameMsg(const uint32_t scan_counter = 42,
 {
   const auto resolution{ util::TenthOfDegree(10) };
 
-  const unsigned int num_elements = (end_angle - start_angle) / resolution;
+  const unsigned int num_elements = ((end_angle - start_angle) / resolution).value();
   const double lowest_measurement{ 0. };
   const double highest_measurement{ 10. };
   const std::vector<double> measurements{ generateMeasurements(num_elements, lowest_measurement, highest_measurement) };

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -24,6 +24,7 @@
 #include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
 #include "psen_scan_v2_standalone/configuration/default_parameters.h"
 #include "psen_scan_v2_standalone/util/ip_conversion.h"
+#include "psen_scan_v2_standalone/util/tenth_of_degree.h"
 #include "psen_scan_v2_standalone/scanner_configuration.h"
 #include "psen_scan_v2_standalone/scanner_config_builder.h"
 #include "psen_scan_v2_standalone/scan_range.h"
@@ -294,7 +295,8 @@ TEST_F(ScannerConfigurationTest, shouldReturnCorrectResolutionAfterConstruction)
 TEST_F(ScannerConfigurationTest, shouldHaveCorrectResolutionOnDefault)
 {
   const ScannerConfiguration sc{ createValidDefaultConfig() };
-  EXPECT_EQ(data_conversion_layer::radToTenthDegree(configuration::DEFAULT_SCAN_ANGLE_RESOLUTION), sc.scanResolution());
+  EXPECT_EQ(psen_scan_v2_standalone::util::TenthOfDegree::fromRad(configuration::DEFAULT_SCAN_ANGLE_RESOLUTION),
+            sc.scanResolution());
 }
 
 TEST_F(ScannerConfigurationTest, shouldHaveEnabledIntensitiesAfterConstruction)

--- a/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
+++ b/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
@@ -15,6 +15,14 @@
 
 #include <gtest/gtest.h>
 
+#ifdef __linux__
+#define UNUSED __attribute__((unused))
+#endif
+
+#ifdef _WIN32
+#define UNUSED
+#endif
+
 #include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
 #include "psen_scan_v2_standalone/util/tenth_of_degree.h"
 
@@ -143,9 +151,9 @@ TEST(TenthOfDegreeTest, LargerThanOrEqualComparison)
 
 TEST(TenthOfDegreeTest, shouldThrowUnderflowErrorOnCastToIntOfValuesUnderZero)
 {
-  EXPECT_THROW(std::cout << static_cast<uint16_t>(util::TenthOfDegree(-1))
-                         << " - printed to not be unused. Should throw before!\n",
-               std::underflow_error);
+  uint16_t result UNUSED;  // Macro needed to suppress clang-tidy warning
+  EXPECT_THROW(result = static_cast<uint16_t>(util::TenthOfDegree(-1)), std::underflow_error)
+      << "Should throw underflow error";
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
+++ b/standalone/test/unit_tests/util/unittest_tenth_of_degree.cpp
@@ -15,14 +15,6 @@
 
 #include <gtest/gtest.h>
 
-#ifdef __linux__
-#define UNUSED __attribute__((unused))
-#endif
-
-#ifdef _WIN32
-#define UNUSED
-#endif
-
 #include "psen_scan_v2_standalone/data_conversion_layer/angle_conversions.h"
 #include "psen_scan_v2_standalone/util/tenth_of_degree.h"
 
@@ -147,13 +139,6 @@ TEST(TenthOfDegreeTest, LargerThanOrEqualComparison)
   EXPECT_TRUE(util::TenthOfDegree(2) >= util::TenthOfDegree(1));
   EXPECT_TRUE(util::TenthOfDegree(1) >= util::TenthOfDegree(1));
   EXPECT_FALSE(util::TenthOfDegree(1) >= util::TenthOfDegree(2));
-}
-
-TEST(TenthOfDegreeTest, shouldThrowUnderflowErrorOnCastToIntOfValuesUnderZero)
-{
-  uint16_t result UNUSED;  // Macro needed to suppress clang-tidy warning
-  EXPECT_THROW(result = static_cast<uint16_t>(util::TenthOfDegree(-1)), std::underflow_error)
-      << "Should throw underflow error";
 }
 
 }  // namespace psen_scan_v2_standalone_test


### PR DESCRIPTION
Removes the imho unnecessary member function `constexpr operator uint16_t() const` from `TenthOfDegree`.
Mathematical operations should talk place within the type as long as possible and convertion should be done explicitly at the last moment possible.