### PR TITLE
Removing usage and dependancy of pilz_testutils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Remove dependency on pilz_testutils
 * Always build hardware tests
 * Internal refactorings
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,6 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
   find_package(roslaunch REQUIRED)
-  find_package(pilz_testutils REQUIRED)
 
   if(ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)
@@ -179,7 +178,6 @@ if(CATKIN_ENABLE_TESTING)
 
   roslaunch_add_file_check(launch DEPENDENCIES ${PROJECT_NAME}_node)
 
-  include_directories(SYSTEM ${pilz_testutils_INCLUDE_DIRS})
   include_directories(
     standalone/include
     standalone/test/include
@@ -358,7 +356,6 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(integrationtest_udp_client
     ${catkin_LIBRARIES}
-    ${pilz_testutils_LIBRARIES}
     fmt::fmt
   )
 
@@ -379,7 +376,6 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(integrationtest_scanner_api
     ${catkin_LIBRARIES}
-    ${pilz_testutils_LIBRARIES}
     fmt::fmt
   )
 
@@ -392,7 +388,6 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(integrationtest_ros_scanner_node
     ${catkin_LIBRARIES}
-    ${pilz_testutils_LIBRARIES}
     fmt::fmt
   )
 
@@ -402,7 +397,6 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(unittest_ros_parameter_handler
     ${catkin_LIBRARIES}
-    ${pilz_testutils_LIBRARIES}
   )
 
   ######################
@@ -485,7 +479,6 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(hwtest_scan_compare
     ${catkin_LIBRARIES}
-    ${pilz_testutils_LIBRARIES}
     ${rosbag_LIBRARIES}
     fmt::fmt
   )

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,6 @@
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>roslaunch</test_depend>
-  <test_depend>pilz_testutils</test_depend>
   <test_depend>rosbag</test_depend>
 
 </package>


### PR DESCRIPTION
## Description

These changes remove the pilz_testutil dependency in favour of the standalone util barrier

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
   It's not urgent.
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
