### PR TITLE
Switch to colcon for CI coverage build

### DIFF
--- a/.github/workflows/ci_action_noetic.yml
+++ b/.github/workflows/ci_action_noetic.yml
@@ -54,4 +54,4 @@ jobs:
           BUILDER: colcon
           CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"'
           DOCKER_RUN_OPTS: '-e COVERAGE_EXCLUDES="*/psen_scan_v2/src/psen_scan_driver.cpp"'
-          AFTER_SCRIPT: 'git clone --depth=1 --branch feature/colcon_coverage https://github.com/PilzDE/industrial_ci_addons.git /industrial_ci_addons && source /industrial_ci_addons/check_coverage.sh && check_coverage psen_scan_v2'
+          AFTER_SCRIPT: 'git clone --depth=1 --branch master https://github.com/PilzDE/industrial_ci_addons.git /industrial_ci_addons && source /industrial_ci_addons/check_coverage.sh && check_coverage psen_scan_v2'


### PR DESCRIPTION
## Description

These changes are in preparation of the ROS2 port.

Before merge:
- [x] https://github.com/PilzDE/industrial_ci_addons/pull/9
- [x] Revert 2612d78