### PR TITLE
Remove outdated todo

### DIFF
--- a/standalone/src/data_conversion_layer/scanner_reply_serialization_deserialization.cpp
+++ b/standalone/src/data_conversion_layer/scanner_reply_serialization_deserialization.cpp
@@ -46,7 +46,6 @@ RawData data_conversion_layer::scanner_reply::serialize(const uint32_t op_code, 
   raw_processing::write(os, op_code);
   raw_processing::write(os, res_code);
 
-  // TODO check limits
   const std::string data_str(os.str());
   assert(data_str.length() == data_conversion_layer::scanner_reply::Message::SIZE &&
          "Message data of start reply has not the expected size");


### PR DESCRIPTION
This "TODO" originated in the `RawType` being of fixed size, which is no longer the case.

Original code:
https://github.com/pilzde/psen_scan_v2/blob/b6b6f3c63b3a126a8e2746cd7d6733daa8885e8a/include/psen_scan_v2/reply_msg_from_scanner.h
```
  using RawType = std::array<char, REPLY_MSG_FROM_SCANNER_SIZE>;
```
```
inline ReplyMsgFromScanner::RawType ReplyMsgFromScanner::toCharArray()
{
  std::ostringstream os;

  uint32_t crc{ calcCRC(*this) };
  os.write((char*)&crc, sizeof(uint32_t));
  os.write((char*)&reserved_, sizeof(uint32_t));
  os.write((char*)&opcode_, sizeof(uint32_t));
  os.write((char*)&res_code_, sizeof(uint32_t));

  ReplyMsgFromScanner::RawType ret_val{};

  // TODO check limits
  std::string data_str(os.str());
  assert(data_str.length() == REPLY_MSG_FROM_SCANNER_SIZE && "Message data of start reply has not the expected size");
  std::copy(data_str.begin(), data_str.end(), ret_val.begin());

  return ret_val;
}
```