### PR TITLE
Make barrier releasable multiple times without throw

### DIFF
--- a/standalone/include/psen_scan_v2_standalone/util/async_barrier.h
+++ b/standalone/include/psen_scan_v2_standalone/util/async_barrier.h
@@ -18,6 +18,7 @@
 #include <future>
 #include <thread>
 #include <chrono>
+#include <atomic>
 
 namespace psen_scan_v2_standalone
 {
@@ -35,12 +36,16 @@ public:
 
 private:
   std::promise<void> barrier_;
+  std::atomic_flag is_released_ = ATOMIC_FLAG_INIT;
   const std::future<void> future_{ barrier_.get_future() };
 };
 
 inline void util::Barrier::release()
 {
-  barrier_.set_value();
+  if (!is_released_.test_and_set())
+  {
+    barrier_.set_value();
+  }
 }
 
 template <class Rep, class Period>


### PR DESCRIPTION
## Description

These changes Fix the problem that the barrier can only opened once and thus not be used in OnCall().WillByDefault(OpenBarrier(&b))

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests

</details>
