### PR TITLE
Check for valid future and exception of scanner start()/stop()

### DIFF
--- a/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
@@ -25,7 +25,7 @@ namespace psen_scan_v2_standalone_test
 
 #define EXPECT_BARRIER_OPENS(barrier, wait_timeout) EXPECT_TRUE(barrier.waitTillRelease(wait_timeout))
 
-#define EXPECT_DOES_NOT_BLOCK_NOR_THROW(statement)                                                                     \
+#define EXPECT_NO_BLOCK_NO_THROW(statement)                                                                     \
   do                                                                                                                   \
   {                                                                                                                    \
     auto future = std::async(std::launch::async, [&]() { statement });                                                 \

--- a/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
@@ -25,11 +25,13 @@ namespace psen_scan_v2_standalone_test
 
 #define EXPECT_BARRIER_OPENS(barrier, wait_timeout) EXPECT_TRUE(barrier.waitTillRelease(wait_timeout))
 
-#define EXPECT_DOES_NOT_BLOCK(statement)                                                                               \
+#define EXPECT_DOES_NOT_BLOCK_NOR_THROW(statement)                                                                     \
   do                                                                                                                   \
   {                                                                                                                    \
-    const auto future = std::async(std::launch::async, [&]() { statement });                                           \
+    auto future = std::async(std::launch::async, [&]() { statement });                                                 \
+    EXPECT_TRUE(future.valid());                                                                                       \
     EXPECT_FUTURE_IS_READY(future, std::chrono::seconds{ 1 }) << #statement << " does not return.";                    \
+    EXPECT_NO_THROW(future.get();) << #statement << " does throw an exception.";                                       \
   } while (false)  // https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block
 }  // namespace psen_scan_v2_standalone_test
 

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -90,7 +90,7 @@ public:
     util::Barrier start_req_barrier;                                                                                   \
     std::future<void> start_future;                                                                                    \
     EXPECT_START_REQUEST_CALL(*hw_mock, *config).WillOnce(OpenBarrier(&start_req_barrier));                            \
-    EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver->start(););                                                  \
+    EXPECT_NO_BLOCK_NO_THROW(start_future = driver->start(););                                                  \
     EXPECT_TRUE(start_future.valid());                                                                                 \
     EXPECT_BARRIER_OPENS(start_req_barrier, DEFAULT_TIMEOUT) << "Start request not received";                          \
     hw_mock->sendStartReply();                                                                                         \
@@ -103,7 +103,7 @@ public:
     util::Barrier stop_req_barrier;                                                                                    \
     std::future<void> stop_future;                                                                                     \
     EXPECT_STOP_REQUEST_CALL(*hw_mock).WillOnce(OpenBarrier(&stop_req_barrier));                                       \
-    EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver->stop(););                                                    \
+    EXPECT_NO_BLOCK_NO_THROW(stop_future = driver->stop(););                                                    \
     EXPECT_TRUE(stop_future.valid());                                                                                  \
     EXPECT_BARRIER_OPENS(stop_req_barrier, DEFAULT_TIMEOUT) << "Stop request not received";                            \
     hw_mock->sendStopReply();                                                                                          \
@@ -174,7 +174,7 @@ TEST_F(ScannerAPITests, shouldSendStartRequestAndReturnValidFutureWhenLaunchingW
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
+  EXPECT_NO_BLOCK_NO_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
   EXPECT_FUTURE_TIMEOUT(start_future, FUTURE_WAIT_TIMEOUT) << "Scanner::start() finished without receiveing reply";
@@ -194,7 +194,7 @@ TEST_F(ScannerAPITests, shouldReceiveStartRequestWithCorrectHostIpWhenUsingAutoI
       .WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
+  EXPECT_NO_BLOCK_NO_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
   hw_mock_->sendStartReply();
@@ -213,12 +213,12 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStartIsCalledSecondTime)
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
+  EXPECT_NO_BLOCK_NO_THROW(start_future = driver_->start(););
   EXPECT_TRUE(start_future.valid()) << "First call too Scanner::start() should return VALID std::future";
   for (int i = 0; i < 5; ++i)
   {
     std::future<void> second_start_future;
-    EXPECT_DOES_NOT_BLOCK_NOR_THROW(second_start_future = driver_->start(););
+    EXPECT_NO_BLOCK_NO_THROW(second_start_future = driver_->start(););
     EXPECT_FALSE(second_start_future.valid()) << "Subsequenct calls to Scanner::start() should return INVALID "
                                                  "std::future";
   }
@@ -239,7 +239,7 @@ TEST_F(ScannerAPITests, startShouldSucceedDespiteUnexpectedMonitoringFrame)
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
+  EXPECT_NO_BLOCK_NO_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
 
@@ -263,7 +263,7 @@ TEST_F(ScannerAPITests, shouldSendStopRequestAndValidFutureOnStopCall)
   EXPECT_STOP_REQUEST_CALL(*hw_mock_).WillOnce(OpenBarrier(&stop_req_received_barrier));
 
   std::future<void> stop_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver_->stop(););
+  EXPECT_NO_BLOCK_NO_THROW(stop_future = driver_->stop(););
 
   EXPECT_BARRIER_OPENS(stop_req_received_barrier, DEFAULT_TIMEOUT) << "Stop request not received";
   EXPECT_FUTURE_TIMEOUT(stop_future, FUTURE_WAIT_TIMEOUT) << "Scanner::stop() finished without receiveing reply";
@@ -282,12 +282,12 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStopIsCalledSecondTime)
   EXPECT_STOP_REQUEST_CALL(*hw_mock_).WillOnce(OpenBarrier(&stop_req_received_barrier));
 
   std::future<void> stop_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver_->stop(););
+  EXPECT_NO_BLOCK_NO_THROW(stop_future = driver_->stop(););
   EXPECT_TRUE(stop_future.valid()) << "First call too Scanner::stop() should return VALID std::future";
   for (int i = 0; i < 5; ++i)
   {
     std::future<void> second_stop_future;
-    EXPECT_DOES_NOT_BLOCK_NOR_THROW(second_stop_future = driver_->stop(););
+    EXPECT_NO_BLOCK_NO_THROW(second_stop_future = driver_->stop(););
     EXPECT_FALSE(second_stop_future.valid())
         << "Subsequenct calls to Scanner::stop() should return INVALID std::future";
   }
@@ -322,7 +322,7 @@ TEST_F(ScannerAPITests, shouldResendStartRequestIfNoStartReplyIsSent)
   EXPECT_LOG_SHORT(INFO, "ScannerController: Scanner started successfully.").Times(1);
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
+  EXPECT_NO_BLOCK_NO_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(error_msg_barrier, DEFAULT_TIMEOUT) << "Error message not received";
   EXPECT_BARRIER_OPENS(twice_called_barrier, 5000ms) << "Start reply not send at least twice in time";

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -90,7 +90,8 @@ public:
     util::Barrier start_req_barrier;                                                                                   \
     std::future<void> start_future;                                                                                    \
     EXPECT_START_REQUEST_CALL(*hw_mock, *config).WillOnce(OpenBarrier(&start_req_barrier));                            \
-    EXPECT_DOES_NOT_BLOCK(start_future = driver->start(););                                                            \
+    EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver->start(););                                                  \
+    EXPECT_TRUE(start_future.valid());                                                                                 \
     EXPECT_BARRIER_OPENS(start_req_barrier, DEFAULT_TIMEOUT) << "Start request not received";                          \
     hw_mock->sendStartReply();                                                                                         \
     EXPECT_FUTURE_IS_READY(start_future, DEFAULT_TIMEOUT) << "Scanner::start() not finished";                          \
@@ -102,7 +103,8 @@ public:
     util::Barrier stop_req_barrier;                                                                                    \
     std::future<void> stop_future;                                                                                     \
     EXPECT_STOP_REQUEST_CALL(*hw_mock).WillOnce(OpenBarrier(&stop_req_barrier));                                       \
-    EXPECT_DOES_NOT_BLOCK(stop_future = driver->stop(););                                                              \
+    EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver->stop(););                                                    \
+    EXPECT_TRUE(stop_future.valid());                                                                                  \
     EXPECT_BARRIER_OPENS(stop_req_barrier, DEFAULT_TIMEOUT) << "Stop request not received";                            \
     hw_mock->sendStopReply();                                                                                          \
     EXPECT_FUTURE_IS_READY(stop_future, DEFAULT_TIMEOUT) << "Scanner::stop() not finished";                            \
@@ -172,7 +174,7 @@ TEST_F(ScannerAPITests, shouldSendStartRequestAndReturnValidFutureWhenLaunchingW
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK(start_future = driver_->start(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
   EXPECT_FUTURE_TIMEOUT(start_future, FUTURE_WAIT_TIMEOUT) << "Scanner::start() finished without receiveing reply";
@@ -192,7 +194,7 @@ TEST_F(ScannerAPITests, shouldReceiveStartRequestWithCorrectHostIpWhenUsingAutoI
       .WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK(start_future = driver_->start(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
   hw_mock_->sendStartReply();
@@ -211,12 +213,12 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStartIsCalledSecondTime)
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK(start_future = driver_->start(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
   EXPECT_TRUE(start_future.valid()) << "First call too Scanner::start() should return VALID std::future";
   for (int i = 0; i < 5; ++i)
   {
     std::future<void> second_start_future;
-    EXPECT_DOES_NOT_BLOCK(second_start_future = driver_->start(););
+    EXPECT_DOES_NOT_BLOCK_NOR_THROW(second_start_future = driver_->start(););
     EXPECT_FALSE(second_start_future.valid()) << "Subsequenct calls to Scanner::start() should return INVALID "
                                                  "std::future";
   }
@@ -237,7 +239,7 @@ TEST_F(ScannerAPITests, startShouldSucceedDespiteUnexpectedMonitoringFrame)
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK(start_future = driver_->start(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(start_req_received_barrier, DEFAULT_TIMEOUT) << "Start request not received";
 
@@ -261,7 +263,7 @@ TEST_F(ScannerAPITests, shouldSendStopRequestAndValidFutureOnStopCall)
   EXPECT_STOP_REQUEST_CALL(*hw_mock_).WillOnce(OpenBarrier(&stop_req_received_barrier));
 
   std::future<void> stop_future;
-  EXPECT_DOES_NOT_BLOCK(stop_future = driver_->stop(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver_->stop(););
 
   EXPECT_BARRIER_OPENS(stop_req_received_barrier, DEFAULT_TIMEOUT) << "Stop request not received";
   EXPECT_FUTURE_TIMEOUT(stop_future, FUTURE_WAIT_TIMEOUT) << "Scanner::stop() finished without receiveing reply";
@@ -280,12 +282,12 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStopIsCalledSecondTime)
   EXPECT_STOP_REQUEST_CALL(*hw_mock_).WillOnce(OpenBarrier(&stop_req_received_barrier));
 
   std::future<void> stop_future;
-  EXPECT_DOES_NOT_BLOCK(stop_future = driver_->stop(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(stop_future = driver_->stop(););
   EXPECT_TRUE(stop_future.valid()) << "First call too Scanner::stop() should return VALID std::future";
   for (int i = 0; i < 5; ++i)
   {
     std::future<void> second_stop_future;
-    EXPECT_DOES_NOT_BLOCK(second_stop_future = driver_->stop(););
+    EXPECT_DOES_NOT_BLOCK_NOR_THROW(second_stop_future = driver_->stop(););
     EXPECT_FALSE(second_stop_future.valid())
         << "Subsequenct calls to Scanner::stop() should return INVALID std::future";
   }
@@ -320,7 +322,7 @@ TEST_F(ScannerAPITests, shouldResendStartRequestIfNoStartReplyIsSent)
   EXPECT_LOG_SHORT(INFO, "ScannerController: Scanner started successfully.").Times(1);
 
   std::future<void> start_future;
-  EXPECT_DOES_NOT_BLOCK(start_future = driver_->start(););
+  EXPECT_DOES_NOT_BLOCK_NOR_THROW(start_future = driver_->start(););
 
   EXPECT_BARRIER_OPENS(error_msg_barrier, DEFAULT_TIMEOUT) << "Error message not received";
   EXPECT_BARRIER_OPENS(twice_called_barrier, 5000ms) << "Start reply not send at least twice in time";


### PR DESCRIPTION
**edit: hold until we know if `scanner.start()`/`stop()` persist**

We expect that scanner.start() and stop() do not throw, so this was missing

## Description

These changes hopefully shed some light on #262.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] Copyright headers
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
