### PR TITLE
convenience usage of ScannerConfiguration

### DIFF
--- a/src/psen_scan_driver.cpp
+++ b/src/psen_scan_driver.cpp
@@ -82,13 +82,12 @@ int main(int argc, char** argv)
                                                            pnh, PARAM_ANGLE_END, configuration::DEFAULT_ANGLE_END)) };
 
     ScannerConfiguration scanner_configuration{
-      ScannerConfigurationBuilder()
+      ScannerConfigurationBuilder(getRequiredParamFromServer<std::string>(pnh, PARAM_SCANNER_IP))
           .hostIP(getOptionalParamFromServer<std::string>(pnh, PARAM_HOST_IP, configuration::DEFAULT_HOST_IP_STRING))
           .hostDataPort(
               getOptionalParamFromServer<int>(pnh, PARAM_HOST_DATA_PORT, configuration::DATA_PORT_OF_HOST_DEVICE))
           .hostControlPort(
               getOptionalParamFromServer<int>(pnh, PARAM_HOST_CONTROL_PORT, configuration::CONTROL_PORT_OF_HOST_DEVICE))
-          .scannerIp(getRequiredParamFromServer<std::string>(pnh, PARAM_SCANNER_IP))
           .scannerDataPort(configuration::DATA_PORT_OF_SCANNER_DEVICE)
           .scannerControlPort(configuration::CONTROL_PORT_OF_SCANNER_DEVICE)
           .scanRange(scan_range)

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -34,7 +34,7 @@ namespace psen_scan_v2_standalone
 class ScannerConfigurationBuilder
 {
 public:
-  ScannerConfigurationBuilder(const std::string& scanner_ip); // IP is mandatory
+  ScannerConfigurationBuilder(const std::string& scanner_ip);  // IP is mandatory
   ScannerConfiguration build() const;
 
 public:
@@ -49,7 +49,7 @@ public:
   ScannerConfigurationBuilder& enableDiagnostics(const bool&);
   ScannerConfigurationBuilder& enableIntensities(const bool&);
   ScannerConfigurationBuilder& enableFragmentedScans(const bool&);
-  operator ScannerConfiguration() {return build();}
+  operator ScannerConfiguration();
 
 private:
   static uint16_t convertPort(const int& port);
@@ -150,6 +150,12 @@ inline ScannerConfigurationBuilder& ScannerConfigurationBuilder::enableFragmente
   config_.fragmented_scans_ = enable;
   return *this;
 }
+
+ScannerConfigurationBuilder::operator ScannerConfiguration()
+{
+  return build();
+}
+
 }  // namespace psen_scan_v2_standalone
 
 #endif  // PSEN_SCAN_V2_STANDALONE_SCANNER_CONFIG_BUILDER_H

--- a/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_config_builder.h
@@ -34,6 +34,7 @@ namespace psen_scan_v2_standalone
 class ScannerConfigurationBuilder
 {
 public:
+  ScannerConfigurationBuilder(const std::string& scanner_ip); // IP is mandatory
   ScannerConfiguration build() const;
 
 public:
@@ -48,6 +49,7 @@ public:
   ScannerConfigurationBuilder& enableDiagnostics(const bool&);
   ScannerConfigurationBuilder& enableIntensities(const bool&);
   ScannerConfigurationBuilder& enableFragmentedScans(const bool&);
+  operator ScannerConfiguration() {return build();}
 
 private:
   static uint16_t convertPort(const int& port);
@@ -55,6 +57,11 @@ private:
 private:
   ScannerConfiguration config_;
 };
+
+ScannerConfigurationBuilder::ScannerConfigurationBuilder(const std::string& scanner_ip)
+{
+  scannerIp(scanner_ip);
+}
 
 inline ScannerConfiguration ScannerConfigurationBuilder::build() const
 {

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -46,8 +46,8 @@ int main(int argc, char** argv)
 
   // Available configuration options are listed on
   // http://docs.ros.org/en/melodic/api/psen_scan_v2/html/classpsen__scan__v2__standalone_1_1ScannerConfigurationBuilder.html
-  auto config = ScannerConfigurationBuilder(SCANNER_IP).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
-  ScannerV2 scanner(config, laserScanCallback);
+  ScannerV2 scanner(ScannerConfigurationBuilder(SCANNER_IP).scanRange(ScanRange{ ANGLE_START, ANGLE_END }),
+                    laserScanCallback);
 
   scanner.start();
   std::this_thread::sleep_for(std::chrono::seconds(10));

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -46,10 +46,8 @@ int main(int argc, char** argv)
 
   // Available configuration options are listed on
   // http://docs.ros.org/en/melodic/api/psen_scan_v2/html/classpsen__scan__v2__standalone_1_1ScannerConfigurationBuilder.html
-  ScannerConfigurationBuilder config_builder;
-  config_builder.scannerIp(SCANNER_IP).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
-
-  ScannerV2 scanner(config_builder.build(), laserScanCallback);
+  auto config = ScannerConfigurationBuilder(SCANNER_IP).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
+  ScannerV2 scanner(config, laserScanCallback);
 
   scanner.start();
   std::this_thread::sleep_for(std::chrono::seconds(10));

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -140,18 +140,16 @@ void ScannerAPITests::setUpScannerConfig(const std::string& host_ip, bool fragme
 
 ScannerConfiguration ScannerAPITests::generateScannerConfig(const std::string& host_ip, bool fragmented)
 {
-  auto config_builder = ScannerConfigurationBuilder()
-                            .hostIP(host_ip)
-                            .hostDataPort(port_holder_.data_port_host)
-                            .hostControlPort(port_holder_.control_port_host)
-                            .scannerIp(SCANNER_IP_ADDRESS)
-                            .scannerDataPort(port_holder_.data_port_scanner)
-                            .scannerControlPort(port_holder_.control_port_scanner)
-                            .scanRange(DEFAULT_SCAN_RANGE)
-                            .scanResolution(DEFAULT_SCAN_RESOLUTION)
-                            .enableIntensities()
-                            .enableFragmentedScans(fragmented);
-  return config_builder.build();
+  return ScannerConfigurationBuilder(SCANNER_IP_ADDRESS)
+      .hostIP(host_ip)
+      .hostDataPort(port_holder_.data_port_host)
+      .hostControlPort(port_holder_.control_port_host)
+      .scannerDataPort(port_holder_.data_port_scanner)
+      .scannerControlPort(port_holder_.control_port_scanner)
+      .scanRange(DEFAULT_SCAN_RANGE)
+      .scanResolution(DEFAULT_SCAN_RESOLUTION)
+      .enableIntensities()
+      .enableFragmentedScans(fragmented);
 }
 
 void ScannerAPITests::setUpScannerV2Driver()

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -90,7 +90,7 @@ public:
     util::Barrier start_req_barrier;                                                                                   \
     std::future<void> start_future;                                                                                    \
     EXPECT_START_REQUEST_CALL(*hw_mock, *config).WillOnce(OpenBarrier(&start_req_barrier));                            \
-    EXPECT_NO_BLOCK_NO_THROW(start_future = driver->start(););                                                  \
+    EXPECT_NO_BLOCK_NO_THROW(start_future = driver->start(););                                                         \
     EXPECT_TRUE(start_future.valid());                                                                                 \
     EXPECT_BARRIER_OPENS(start_req_barrier, DEFAULT_TIMEOUT) << "Start request not received";                          \
     hw_mock->sendStartReply();                                                                                         \
@@ -103,7 +103,7 @@ public:
     util::Barrier stop_req_barrier;                                                                                    \
     std::future<void> stop_future;                                                                                     \
     EXPECT_STOP_REQUEST_CALL(*hw_mock).WillOnce(OpenBarrier(&stop_req_barrier));                                       \
-    EXPECT_NO_BLOCK_NO_THROW(stop_future = driver->stop(););                                                    \
+    EXPECT_NO_BLOCK_NO_THROW(stop_future = driver->stop(););                                                           \
     EXPECT_TRUE(stop_future.valid());                                                                                  \
     EXPECT_BARRIER_OPENS(stop_req_barrier, DEFAULT_TIMEOUT) << "Stop request not received";                            \
     hw_mock->sendStopReply();                                                                                          \

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -49,11 +49,10 @@ class ScannerConfigurationTest : public testing::Test
 
 static ScannerConfiguration createValidConfig()
 {
-  return ScannerConfigurationBuilder()
+  return ScannerConfigurationBuilder(VALID_IP)
       .hostIP(VALID_IP)
       .hostDataPort(MAXIMAL_PORT_NUMBER - 1)
       .hostControlPort(MAXIMAL_PORT_NUMBER)
-      .scannerIp(VALID_IP)
       .scannerDataPort(MINIMAL_PORT_NUMBER + 1)
       .scannerControlPort(MINIMAL_PORT_NUMBER + 2)
       .scanRange(SCAN_RANGE)
@@ -65,11 +64,10 @@ static ScannerConfiguration createValidConfig()
 
 static ScannerConfiguration createValidConfig(const std::string& host_ip)
 {
-  return ScannerConfigurationBuilder()
+  return ScannerConfigurationBuilder(VALID_IP)
       .hostIP(host_ip)
       .hostDataPort(MAXIMAL_PORT_NUMBER - 1)
       .hostControlPort(MAXIMAL_PORT_NUMBER)
-      .scannerIp(VALID_IP)
       .scannerDataPort(MINIMAL_PORT_NUMBER + 1)
       .scannerControlPort(MINIMAL_PORT_NUMBER + 2)
       .scanRange(SCAN_RANGE)
@@ -82,7 +80,7 @@ static ScannerConfiguration createValidConfig(const std::string& host_ip)
 
 static ScannerConfiguration createValidDefaultConfig()
 {
-  return ScannerConfigurationBuilder().scannerIp(VALID_IP).scanRange(SCAN_RANGE).build();
+  return ScannerConfigurationBuilder(VALID_IP).scanRange(SCAN_RANGE);
 }
 
 TEST_F(ScannerConfigurationTest, shouldNotThrowInCaseOfValidConfiguration)
@@ -91,26 +89,12 @@ TEST_F(ScannerConfigurationTest, shouldNotThrowInCaseOfValidConfiguration)
   EXPECT_NO_THROW(createValidDefaultConfig());
 }
 
-TEST_F(ScannerConfigurationTest, shouldThrowIfScannerIPMissing)
-{
-  EXPECT_THROW(ScannerConfigurationBuilder()
-                   .hostIP(VALID_IP)
-                   .hostDataPort(MAXIMAL_PORT_NUMBER - 1)
-                   .hostControlPort(MAXIMAL_PORT_NUMBER)
-                   .scannerDataPort(MINIMAL_PORT_NUMBER)
-                   .scannerControlPort(MINIMAL_PORT_NUMBER + 1)
-                   .scanRange(SCAN_RANGE)
-                   .build(),
-               std::runtime_error);
-}
-
 TEST_F(ScannerConfigurationTest, shouldThrowIfScanRangeMissing)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder()
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP)
                    .hostIP(VALID_IP)
                    .hostDataPort(MAXIMAL_PORT_NUMBER - 1)
                    .hostControlPort(MAXIMAL_PORT_NUMBER)
-                   .scannerIp(VALID_IP)
                    .scannerDataPort(MINIMAL_PORT_NUMBER)
                    .scannerControlPort(MINIMAL_PORT_NUMBER + 1)
                    .build(),
@@ -119,62 +103,62 @@ TEST_F(ScannerConfigurationTest, shouldThrowIfScanRangeMissing)
 
 TEST_F(ScannerConfigurationTest, shouldThrowInCaseOfInvalidHostIp)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().hostIP(INVALID_IP), std::invalid_argument);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).hostIP(INVALID_IP), std::invalid_argument);
 }
 
 TEST_F(ScannerConfigurationTest, shouldNotThrowInCaseOfEmptyHostIp)
 {
-  EXPECT_NO_THROW(ScannerConfigurationBuilder().hostIP(EMPTY_IP));
+  EXPECT_NO_THROW(ScannerConfigurationBuilder(VALID_IP).hostIP(EMPTY_IP));
 }
 
 TEST_F(ScannerConfigurationTest, shouldNotThrowInCaseOfAutoHostIp)
 {
-  EXPECT_NO_THROW(ScannerConfigurationBuilder().hostIP(AUTO_IP));
+  EXPECT_NO_THROW(ScannerConfigurationBuilder(VALID_IP).hostIP(AUTO_IP));
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowInCaseOfInvalidScannerIp)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().scannerIp(INVALID_IP), std::invalid_argument);
+  EXPECT_THROW(ScannerConfigurationBuilder(INVALID_IP).build(), std::invalid_argument);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfHostDataPortTooSmall)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().hostDataPort(-1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).hostDataPort(-1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfHostDataPortTooLarge)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().hostDataPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).hostDataPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfHostControlPortTooSmall)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().hostControlPort(MINIMAL_PORT_NUMBER - 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).hostControlPort(MINIMAL_PORT_NUMBER - 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfHostControlPortTooLarge)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().hostControlPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).hostControlPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfScannerDataPortTooSmall)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().scannerDataPort(-1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).scannerDataPort(-1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfScannerDataPortTooLarge)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().scannerDataPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).scannerDataPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfScannerControlPortTooSmall)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().scannerControlPort(MINIMAL_PORT_NUMBER - 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).scannerControlPort(MINIMAL_PORT_NUMBER - 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowIfScannerControlPortTooLarge)
 {
-  EXPECT_THROW(ScannerConfigurationBuilder().scannerControlPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
+  EXPECT_THROW(ScannerConfigurationBuilder(VALID_IP).scannerControlPort(MAXIMAL_PORT_NUMBER + 1), std::out_of_range);
 }
 
 TEST_F(ScannerConfigurationTest, shouldReturnCorrectPortsAfterDefaultConstruction)
@@ -313,22 +297,22 @@ TEST_F(ScannerConfigurationTest, shouldLoadIntensitiesFromConfigByDefault)
 
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithLowResolutionAndEnabledIntensitiesOnBuild)
 {
-  ScannerConfigurationBuilder sb{};
-  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE).enableIntensities().scanResolution(util::TenthOfDegree{ 1u });
+  auto sb = ScannerConfigurationBuilder(VALID_IP)
+                .scanRange(SCAN_RANGE)
+                .enableIntensities()
+                .scanResolution(util::TenthOfDegree{ 1u });
   EXPECT_THROW(sb.build(), std::invalid_argument);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingLowerLimit)
 {
-  ScannerConfigurationBuilder sb{};
-  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE);
+  auto sb = ScannerConfigurationBuilder(VALID_IP).scanRange(SCAN_RANGE);
   EXPECT_THROW(sb.scanResolution(util::TenthOfDegree{ 0u }), std::invalid_argument);
 }
 
 TEST_F(ScannerConfigurationTest, shouldThrowInvalidArgumentWithResolutionViolatingUpperLimit)
 {
-  ScannerConfigurationBuilder sb{};
-  sb.scannerIp(VALID_IP).scanRange(SCAN_RANGE);
+  auto sb = ScannerConfigurationBuilder(VALID_IP).scanRange(SCAN_RANGE);
   EXPECT_THROW(sb.scanResolution(util::TenthOfDegree{ 101u }), std::invalid_argument);
 }
 

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -74,11 +74,10 @@ TEST_F(StartRequestTest, constructorTest)
   const ScanRange scan_range{ util::TenthOfDegree(1), util::TenthOfDegree::fromRad(4.71) };
 
   uint32_t sequence_number{ 123 };
-  data_conversion_layer::start_request::Message sr(ScannerConfigurationBuilder()
+  data_conversion_layer::start_request::Message sr(ScannerConfigurationBuilder("192.168.0.50")
                                                        .hostIP(host_ip)
                                                        .hostDataPort(host_udp_port_data)
                                                        .hostControlPort(1 /* irrelevant */)
-                                                       .scannerIp("192.168.0.50")
                                                        .scannerDataPort(77)
                                                        .scannerControlPort(78)
                                                        .scanRange(scan_range)
@@ -142,10 +141,10 @@ TEST_F(StartRequestTest, endAngleIncreasedWhenMatchingDataPoint)
   const ScanRange scan_range{ util::TenthOfDegree(1u), util::TenthOfDegree(2749u) };
   const util::TenthOfDegree resolution{ 2u };
 
-  ScannerConfigurationBuilder builder;
-  builder.hostIP("192.168.0.50").scannerIp("192.168.0.10").scanResolution(resolution).scanRange(scan_range);
-
-  const ScannerConfiguration config = builder.build();
+  const ScannerConfiguration config = ScannerConfigurationBuilder("192.168.0.10")
+                                          .hostIP("192.168.0.50")
+                                          .scanResolution(resolution)
+                                          .scanRange(scan_range);
 
   const auto raw_start_request{ data_conversion_layer::start_request::serialize(
       data_conversion_layer::start_request::Message(config)) };
@@ -160,15 +159,12 @@ TEST_F(StartRequestTest, endAngleIncreasedWhenMatchingDataPoint)
 
 TEST_F(StartRequestTest, crcWithIntensities)
 {
-  ScannerConfigurationBuilder builder;
-  builder.hostIP("192.168.0.50")
-      .scannerIp("192.168.0.10")
-      .scanResolution(util::TenthOfDegree(2u))
-      .enableIntensities()
-      .scanRange(ScanRange(util::TenthOfDegree(1), util::TenthOfDegree(2749)))
-      .enableDiagnostics();
-
-  const ScannerConfiguration config = builder.build();
+  const ScannerConfiguration config = ScannerConfigurationBuilder("192.168.0.10")
+                                          .hostIP("192.168.0.50")
+                                          .scanResolution(util::TenthOfDegree(2u))
+                                          .enableIntensities()
+                                          .scanRange(ScanRange(util::TenthOfDegree(1), util::TenthOfDegree(2749)))
+                                          .enableDiagnostics();
 
   const auto raw_start_request{ data_conversion_layer::start_request::serialize(
       data_conversion_layer::start_request::Message(config)) };

--- a/test/hw_tests/hwtest_scan_compare_standalone.cpp
+++ b/test/hw_tests/hwtest_scan_compare_standalone.cpp
@@ -93,10 +93,10 @@ TEST_F(ScanComparisonTests, simpleCompare)
 
   ScanRange scan_range{ ANGLE_START, ANGLE_END };
 
-  ScannerConfigurationBuilder config_builder;
-  config_builder.hostIP(host_ip_).scannerIp(scanner_ip_).hostDataPort(HOST_UDP_PORT_DATA).scanRange(scan_range);
+  ScannerConfigurationBuilder config_builder { scanner_ip_};
+  config_builder.hostIP(host_ip_).hostDataPort(HOST_UDP_PORT_DATA).scanRange(scan_range);
 
-  ScannerV2 scanner(config_builder.build(), [&laser_scan_validator, &window_size](const ScanType& scan) {
+  ScannerV2 scanner(config_builder, [&laser_scan_validator, &window_size](const ScanType& scan) {
     return laser_scan_validator.scanCb(boost::make_shared<ScanType const>(scan), window_size, -1375);
   });
   scanner.start();

--- a/test/hw_tests/hwtest_scan_compare_standalone.cpp
+++ b/test/hw_tests/hwtest_scan_compare_standalone.cpp
@@ -93,7 +93,7 @@ TEST_F(ScanComparisonTests, simpleCompare)
 
   ScanRange scan_range{ ANGLE_START, ANGLE_END };
 
-  ScannerConfigurationBuilder config_builder { scanner_ip_};
+  ScannerConfigurationBuilder config_builder{ scanner_ip_ };
   config_builder.hostIP(host_ip_).hostDataPort(HOST_UDP_PORT_DATA).scanRange(scan_range);
 
   ScannerV2 scanner(config_builder, [&laser_scan_validator, &window_size](const ScanType& scan) {

--- a/test/hw_tests/hwtest_timestamp_standalone.cpp
+++ b/test/hw_tests/hwtest_timestamp_standalone.cpp
@@ -83,7 +83,7 @@ protected:
 private:
   void buildScannerConfig()
   {
-    ScannerConfigurationBuilder config_builder { SCANNER_IP };
+    ScannerConfigurationBuilder config_builder{ SCANNER_IP };
     config_builder.hostDataPort(HOST_UDP_DATA_PORT).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
 
     if (const char* host_ip{ std::getenv("HOST_IP") })

--- a/test/hw_tests/hwtest_timestamp_standalone.cpp
+++ b/test/hw_tests/hwtest_timestamp_standalone.cpp
@@ -83,10 +83,8 @@ protected:
 private:
   void buildScannerConfig()
   {
-    ScannerConfigurationBuilder config_builder;
-    config_builder.scannerIp(SCANNER_IP)
-        .hostDataPort(HOST_UDP_DATA_PORT)
-        .scanRange(ScanRange{ ANGLE_START, ANGLE_END });
+    ScannerConfigurationBuilder config_builder { SCANNER_IP };
+    config_builder.hostDataPort(HOST_UDP_DATA_PORT).scanRange(ScanRange{ ANGLE_START, ANGLE_END });
 
     if (const char* host_ip{ std::getenv("HOST_IP") })
     {
@@ -98,7 +96,7 @@ private:
       config_builder.scannerIp(scanner_ip);
     }
 
-    scanner_config_.reset(new ScannerConfiguration(config_builder.build()));
+    scanner_config_.reset(new ScannerConfiguration(config_builder));
   }
 
 private:

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -100,15 +100,13 @@ static void setDefaultActions(ScannerMock& mock, util::Barrier& start_barrier)
 
 static ScannerConfiguration createValidConfig()
 {
-  return ScannerConfigurationBuilder()
+  return ScannerConfigurationBuilder(DEVICE_IP)
       .hostIP(HOST_IP)
       .hostDataPort(HOST_UDP_PORT_DATA)
       .hostControlPort(HOST_UDP_PORT_CONTROL)
-      .scannerIp(DEVICE_IP)
       .scannerDataPort(configuration::DATA_PORT_OF_SCANNER_DEVICE)
       .scannerControlPort(configuration::CONTROL_PORT_OF_SCANNER_DEVICE)
-      .scanRange(SCAN_RANGE)
-      .build();
+      .scanRange(SCAN_RANGE);
 }
 
 static LaserScan createValidLaserScan(const uint8_t active_zoneset = 1)


### PR DESCRIPTION
IP address is the only mandatory argument, so make it a param of the constructor to
always have a valid config. The builder is implicitly convertible into a configuration,
to save the user from typing build() in every situation.

This simplifies the main.cpp into more readable and convenient:
```
auto config = ScannerConfigurationBuilder(SCANNER_IP).scanRange(ScanRange{ ... });
ScannerV2 scanner(config, laserScanCallback);
```

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [x] Examples

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
