### PR TITLE
Refactor/integrationtest scanner api

### DIFF
--- a/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
@@ -40,7 +40,7 @@ using namespace std::chrono_literals;
   {                                                                                                                    \
     auto future = std::async(std::launch::async, [&]() { statement });                                                 \
     EXPECT_TRUE(future.valid());                                                                                       \
-    EXPECT_FUTURE_IS_READY(future, 2s) << #statement << " does not return.";                    \
+    EXPECT_FUTURE_IS_READY(future, 2s) << #statement << " does not return.";                                           \
     EXPECT_NO_THROW(future.get();) << #statement << " does throw an exception.";                                       \
   } while (false)  // https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block
 

--- a/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/expectations.h
@@ -26,6 +26,8 @@
 
 namespace psen_scan_v2_standalone_test
 {
+using namespace std::chrono_literals;
+
 #define EXPECT_FUTURE_IS_READY(future, wait_timeout) EXPECT_EQ(future.wait_for(wait_timeout), std::future_status::ready)
 
 #define EXPECT_FUTURE_TIMEOUT(future, wait_timeout)                                                                    \
@@ -38,7 +40,7 @@ namespace psen_scan_v2_standalone_test
   {                                                                                                                    \
     auto future = std::async(std::launch::async, [&]() { statement });                                                 \
     EXPECT_TRUE(future.valid());                                                                                       \
-    EXPECT_FUTURE_IS_READY(future, std::chrono::seconds{ 1 }) << #statement << " does not return.";                    \
+    EXPECT_FUTURE_IS_READY(future, 2s) << #statement << " does not return.";                    \
     EXPECT_NO_THROW(future.get();) << #statement << " does throw an exception.";                                       \
   } while (false)  // https://stackoverflow.com/questions/1067226/c-multi-line-macro-do-while0-vs-scope-block
 

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -163,11 +163,20 @@ void ScannerAPITests::setUpScannerHwMock()
   hw_mock_.reset(new StrictMock<ScannerMock>{ HOST_IP_ADDRESS, port_holder_ });
 }
 
-TEST_F(ScannerAPITests, shouldSendStartRequestAndReturnValidFutureWhenLaunchingWithValidConfig)
+class ScannerAPITestsFragmented : public ScannerAPITests
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
+  void SetUp() override
+  {
+    port_holder_.printPorts();
+    setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
+    setUpScannerConfig();
+    setUpScannerV2Driver();
+    setUpScannerHwMock();
+  }
+};
+
+TEST_F(ScannerAPITestsFragmented, shouldSendStartRequestAndReturnValidFutureWhenLaunchingWithValidConfig)
+{
   util::Barrier start_req_received_barrier;
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
@@ -201,12 +210,8 @@ TEST_F(ScannerAPITests, shouldReceiveStartRequestWithCorrectHostIpWhenUsingAutoI
   EXPECT_SCANNER_TO_STOP_SUCCESSFULLY(hw_mock_, driver_);
 }
 
-TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStartIsCalledSecondTime)
+TEST_F(ScannerAPITestsFragmented, shouldReturnInvalidFutureWhenStartIsCalledSecondTime)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
-
   util::Barrier start_req_received_barrier;
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
@@ -227,12 +232,8 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStartIsCalledSecondTime)
   EXPECT_SCANNER_TO_STOP_SUCCESSFULLY(hw_mock_, driver_);
 }
 
-TEST_F(ScannerAPITests, startShouldReturnFutureWithExceptionIfStartRequestRefused)
+TEST_F(ScannerAPITestsFragmented, startShouldReturnFutureWithExceptionIfStartRequestRefused)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
-
   util::Barrier start_req_received_barrier;
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
@@ -244,12 +245,8 @@ TEST_F(ScannerAPITests, startShouldReturnFutureWithExceptionIfStartRequestRefuse
   EXPECT_THROW_AND_WHAT(start_future.get(), std::runtime_error, "Request refused by device.");
 }
 
-TEST_F(ScannerAPITests, startShouldReturnFutureWithExceptionIfUnknownResultSent)
+TEST_F(ScannerAPITestsFragmented, startShouldReturnFutureWithExceptionIfUnknownResultSent)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
-
   util::Barrier start_req_received_barrier;
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
@@ -266,12 +263,8 @@ TEST_F(ScannerAPITests, startShouldReturnFutureWithExceptionIfUnknownResultSent)
           .c_str());
 }
 
-TEST_F(ScannerAPITests, startShouldSucceedDespiteUnexpectedMonitoringFrame)
+TEST_F(ScannerAPITestsFragmented, startShouldSucceedDespiteUnexpectedMonitoringFrame)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
-
   util::Barrier start_req_received_barrier;
   EXPECT_START_REQUEST_CALL(*hw_mock_, *config_).WillOnce(OpenBarrier(&start_req_received_barrier));
 
@@ -289,11 +282,8 @@ TEST_F(ScannerAPITests, startShouldSucceedDespiteUnexpectedMonitoringFrame)
   EXPECT_SCANNER_TO_STOP_SUCCESSFULLY(hw_mock_, driver_);
 }
 
-TEST_F(ScannerAPITests, shouldSendStopRequestAndValidFutureOnStopCall)
+TEST_F(ScannerAPITestsFragmented, shouldSendStopRequestAndValidFutureOnStopCall)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   util::Barrier stop_req_received_barrier;
@@ -308,11 +298,8 @@ TEST_F(ScannerAPITests, shouldSendStopRequestAndValidFutureOnStopCall)
   EXPECT_FUTURE_IS_READY(stop_future, DEFAULT_TIMEOUT) << "Scanner::stop() not finished";
 }
 
-TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStopIsCalledSecondTime)
+TEST_F(ScannerAPITestsFragmented, shouldReturnInvalidFutureWhenStopIsCalledSecondTime)
 {
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   util::Barrier stop_req_received_barrier;
@@ -334,13 +321,10 @@ TEST_F(ScannerAPITests, shouldReturnInvalidFutureWhenStopIsCalledSecondTime)
   EXPECT_FUTURE_IS_READY(stop_future, DEFAULT_TIMEOUT) << "Scanner::stop() not finished";
 }
 
-TEST_F(ScannerAPITests, shouldResendStartRequestIfNoStartReplyIsSent)
+TEST_F(ScannerAPITestsFragmented, shouldResendStartRequestIfNoStartReplyIsSent)
 {
   INJECT_LOG_MOCK;
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
 
   util::Barrier error_msg_barrier;
   util::Barrier twice_called_barrier;
@@ -370,13 +354,10 @@ TEST_F(ScannerAPITests, shouldResendStartRequestIfNoStartReplyIsSent)
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, LaserScanShouldContainAllInfosTransferedByMonitoringFrameMsg)
+TEST_F(ScannerAPITestsFragmented, LaserScanShouldContainAllInfosTransferedByMonitoringFrameMsg)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   const auto msg{ createValidMonitoringFrameMsg() };
@@ -399,13 +380,10 @@ TEST_F(ScannerAPITests, LaserScanShouldContainAllInfosTransferedByMonitoringFram
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldShowInfoWithNewActiveZonesetOnlyWhenItChanges)
+TEST_F(ScannerAPITestsFragmented, shouldShowInfoWithNewActiveZonesetOnlyWhenItChanges)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   const auto msg1{ createValidMonitoringFrameMsgWithZoneset(2) };
@@ -518,12 +496,9 @@ TEST_F(ScannerAPITests, shouldIgnoreMonitoringFrameOfFormerScanRound)
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldNotCallLaserscanCallbackInCaseOfEmptyMonitoringFrame)
+TEST_F(ScannerAPITestsFragmented, shouldNotCallLaserscanCallbackInCaseOfEmptyMonitoringFrame)
 {
   INJECT_NICE_LOG_MOCK;
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   EXPECT_CALL(user_callbacks_, LaserScanCallback(_)).Times(0);
@@ -543,12 +518,9 @@ TEST_F(ScannerAPITests, shouldNotCallLaserscanCallbackInCaseOfEmptyMonitoringFra
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldNotCallLaserscanCallbackInCaseOfMissingMeassurements)
+TEST_F(ScannerAPITestsFragmented, shouldNotCallLaserscanCallbackInCaseOfMissingMeassurements)
 {
   INJECT_NICE_LOG_MOCK;
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   EXPECT_CALL(user_callbacks_, LaserScanCallback(_)).Times(0);
@@ -574,13 +546,10 @@ TEST_F(ScannerAPITests, shouldThrowWhenConstructedWithInvalidLaserScanCallback)
   EXPECT_THROW(ScannerV2 scanner(*config_, nullptr);, std::invalid_argument);
 }
 
-TEST_F(ScannerAPITests, shouldShowUserMsgIfMonitoringFramesAreMissing)
+TEST_F(ScannerAPITestsFragmented, shouldShowUserMsgIfMonitoringFramesAreMissing)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   const std::size_t num_scans_per_round{ 6 };
@@ -613,13 +582,10 @@ TEST_F(ScannerAPITests, shouldShowUserMsgIfMonitoringFramesAreMissing)
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldShowUserMsgIfTooManyMonitoringFramesAreReceived)
+TEST_F(ScannerAPITestsFragmented, shouldShowUserMsgIfTooManyMonitoringFramesAreReceived)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   const std::size_t num_scans_per_round{ 6 };
@@ -646,13 +612,10 @@ TEST_F(ScannerAPITests, shouldShowUserMsgIfTooManyMonitoringFramesAreReceived)
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldShowUserMsgIfMonitoringFrameReceiveTimeout)
+TEST_F(ScannerAPITestsFragmented, shouldShowUserMsgIfMonitoringFrameReceiveTimeout)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig();
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   util::Barrier user_msg_barrier;

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -435,12 +435,9 @@ TEST_F(ScannerAPITestsUnfragmented, shouldShowOneUserMsgIfFirstTwoScanRoundsStar
   EXPECT_ANY_LOG().Times(AnyNumber());
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
-  std::vector<psen_scan_v2_standalone::data_conversion_layer::monitoring_frame::Message> ignored_short_first_round =
-      createMonitoringFrameMsgsForScanRound(2, 1);
-  std::vector<psen_scan_v2_standalone::data_conversion_layer::monitoring_frame::Message> accounted_short_round =
-      createMonitoringFrameMsgsForScanRound(3, 5);
-  std::vector<psen_scan_v2_standalone::data_conversion_layer::monitoring_frame::Message> valid_round =
-      createMonitoringFrameMsgsForScanRound(4, 6);
+  auto ignored_short_first_round = createMonitoringFrameMsgsForScanRound(2, 1);
+  auto accounted_short_round = createMonitoringFrameMsgsForScanRound(3, 5);
+  auto valid_round = createMonitoringFrameMsgsForScanRound(4, 6);
 
   util::Barrier monitoring_frame_barrier;
   EXPECT_CALLBACK_WILL_OPEN_BARRIER(user_callbacks_, valid_round, monitoring_frame_barrier);

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -166,8 +166,7 @@ class ScannerAPITestsFragmented : public ScannerAPITests
 {
   void SetUp() override
   {
-    port_holder_.printPorts();
-    setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
+    ScannerAPITests::SetUp();
     setUpScannerConfig();
     setUpScannerV2Driver();
     setUpScannerHwMock();
@@ -178,8 +177,7 @@ class ScannerAPITestsUnfragmented : public ScannerAPITests
 {
   void SetUp() override
   {
-    port_holder_.printPorts();
-    setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
+    ScannerAPITests::SetUp();
     setUpScannerConfig(HOST_IP_ADDRESS, UNFRAGMENTED_SCAN);
     setUpScannerV2Driver();
     setUpScannerHwMock();

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -175,6 +175,18 @@ class ScannerAPITestsFragmented : public ScannerAPITests
   }
 };
 
+class ScannerAPITestsUnfragmented : public ScannerAPITests
+{
+  void SetUp() override
+  {
+    port_holder_.printPorts();
+    setLogLevel(CONSOLE_BRIDGE_LOG_DEBUG);
+    setUpScannerConfig(HOST_IP_ADDRESS, UNFRAGMENTED_SCAN);
+    setUpScannerV2Driver();
+    setUpScannerHwMock();
+  }
+};
+
 TEST_F(ScannerAPITestsFragmented, shouldSendStartRequestAndReturnValidFutureWhenLaunchingWithValidConfig)
 {
   util::Barrier start_req_received_barrier;
@@ -404,11 +416,9 @@ TEST_F(ScannerAPITestsFragmented, shouldShowInfoWithNewActiveZonesetOnlyWhenItCh
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldCallLaserScanCallbackOnlyOneTimeWithAllInformationWhenUnfragmentedScanIsEnabled)
+TEST_F(ScannerAPITestsUnfragmented,
+       shouldCallLaserScanCallbackOnlyOneTimeWithAllInformationWhenUnfragmentedScanIsEnabled)
 {
-  setUpScannerConfig(HOST_IP_ADDRESS, UNFRAGMENTED_SCAN);
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   const auto msgs{ createMonitoringFrameMsgsForScanRound(2, 6) };
@@ -422,13 +432,10 @@ TEST_F(ScannerAPITests, shouldCallLaserScanCallbackOnlyOneTimeWithAllInformation
   EXPECT_SCANNER_TO_STOP_SUCCESSFULLY(hw_mock_, driver_);
 }
 
-TEST_F(ScannerAPITests, shouldShowOneUserMsgIfFirstTwoScanRoundsStartEarly)
+TEST_F(ScannerAPITestsUnfragmented, shouldShowOneUserMsgIfFirstTwoScanRoundsStartEarly)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig(HOST_IP_ADDRESS, UNFRAGMENTED_SCAN);
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   std::vector<psen_scan_v2_standalone::data_conversion_layer::monitoring_frame::Message> ignored_short_first_round =
@@ -460,13 +467,10 @@ TEST_F(ScannerAPITests, shouldShowOneUserMsgIfFirstTwoScanRoundsStartEarly)
   REMOVE_LOG_MOCK
 }
 
-TEST_F(ScannerAPITests, shouldIgnoreMonitoringFrameOfFormerScanRound)
+TEST_F(ScannerAPITestsUnfragmented, shouldIgnoreMonitoringFrameOfFormerScanRound)
 {
   INJECT_LOG_MOCK
   EXPECT_ANY_LOG().Times(AnyNumber());
-  setUpScannerConfig(HOST_IP_ADDRESS, UNFRAGMENTED_SCAN);
-  setUpScannerV2Driver();
-  setUpScannerHwMock();
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   auto msg_round2 = createValidMonitoringFrameMsg(2);

--- a/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
+++ b/standalone/test/integration_tests/api/integrationtest_scanner_api.cpp
@@ -498,14 +498,13 @@ TEST_F(ScannerAPITests, shouldIgnoreMonitoringFrameOfFormerScanRound)
 
 TEST_F(ScannerAPITestsFragmented, shouldNotCallLaserscanCallbackInCaseOfEmptyMonitoringFrame)
 {
-  INJECT_NICE_LOG_MOCK;
+  INJECT_LOG_MOCK;
+  EXPECT_ANY_LOG().Times(AnyNumber());
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   EXPECT_CALL(user_callbacks_, LaserScanCallback(_)).Times(0);
 
   util::Barrier empty_msg_received;
-  // Needed to allow all other log messages which might be received
-  EXPECT_ANY_LOG().Times(AnyNumber());
   EXPECT_LOG_SHORT(WARN,
                    "StateMachine: No transition in state \"WaitForMonitoringFrame\" for event "
                    "\"MonitoringFrameReceivedError\".")
@@ -520,14 +519,13 @@ TEST_F(ScannerAPITestsFragmented, shouldNotCallLaserscanCallbackInCaseOfEmptyMon
 
 TEST_F(ScannerAPITestsFragmented, shouldNotCallLaserscanCallbackInCaseOfMissingMeassurements)
 {
-  INJECT_NICE_LOG_MOCK;
+  INJECT_LOG_MOCK;
+  EXPECT_ANY_LOG().Times(AnyNumber());
   EXPECT_SCANNER_TO_START_SUCCESSFULLY(hw_mock_, driver_, config_);
 
   EXPECT_CALL(user_callbacks_, LaserScanCallback(_)).Times(0);
 
   util::Barrier log_msgs_barrier;
-  // Needed to allow all other log messages which might be received
-  EXPECT_ANY_LOG().Times(AnyNumber());
   EXPECT_LOG_SHORT(DEBUG,
                    "StateMachine: No measurement data in current monitoring frame(s), skipping laser scan "
                    "callback.")


### PR DESCRIPTION
## Description

This test aims to improve the integration test readability and reduce its complexity by:
* Using Fixtures for common test setup
* Removing barrier opens expectations (they get opened by expect calls, so there is an expectation already)
* Use chrono literals instead of DEFAULT_TIMEOUT since they are more descriptive
* some smaller cleanups

FYI: I also tried to get rid of the EXPECT_SCANNER_TO_STOP_SUCCESSFULLY and the respective start expectation but:
* We are using a strict mock for the scanner so any call has to be EXPECTed => ON_CALL is no option and there is no ASSERT_CALL 
* we don't want to hide them away so we need to keep them in the tests itself.
* Removing the stop or start completely and expecting everything to still work is unreasonable
* Changing the ScanerMock to just do some actions non asynchrounouse to make the barriers unneccessary and therefore the expectations is at least not easy and maybe not a good idea at all.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
