### PR TITLE
Remove latched from active zoneset topic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Remove latched flag from active zoneset topic
 * Remove unrelated parameter DEFAULT_X_AXIS_ROTATION from standalone
 * Contributors: Pilz GmbH and Co. KG
 

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -89,7 +89,6 @@ private:
   FRIEND_TEST(RosScannerNodeTests, shouldPublishScansWhenLaserScanCallbackIsInvoked);
   FRIEND_TEST(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInvoked);
   FRIEND_TEST(RosScannerNodeTests, shouldWaitWhenStopRequestResponseIsMissing);
-  FRIEND_TEST(RosScannerNodeTests, shouldReceiveLatchedActiveZonesetMsg);
   FRIEND_TEST(RosScannerNodeTests, shouldProvideScanTopic);
   FRIEND_TEST(RosScannerNodeTests, shouldProvideActiveZonesetTopic);
   FRIEND_TEST(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserScan);

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -111,7 +111,7 @@ ROSScannerNodeT<S>::ROSScannerNodeT(ros::NodeHandle& nh,
   , scanner_(scanner_config, std::bind(&ROSScannerNodeT<S>::laserScanCallback, this, std::placeholders::_1))
 {
   pub_scan_ = nh_.advertise<sensor_msgs::LaserScan>(topic, 1);
-  pub_zone_ = nh_.advertise<std_msgs::UInt8>("active_zoneset", 1, true);
+  pub_zone_ = nh_.advertise<std_msgs::UInt8>("active_zoneset", 1);
 }
 
 template <typename S>

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -273,29 +273,6 @@ TEST_F(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInv
   loop.wait_for(LOOP_END_TIMEOUT);
 }
 
-TEST_F(RosScannerNodeTests, shouldReceiveLatchedActiveZonesetMsg)
-{
-  ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
-  util::Barrier start_barrier;
-  setDefaultActions(ros_scanner_node.scanner_, start_barrier);
-
-  const uint8_t first_zone{ 2 };
-
-  util::Barrier zoneset_topic_barrier;
-  SubscriberMock subscriber(nh_priv_);
-  EXPECT_CALL(subscriber, zone_callback(messageEQ(createActiveZonesetMsg(first_zone))))
-      .WillOnce(OpenBarrier(&zoneset_topic_barrier));
-
-  std::future<void> loop = std::async(std::launch::async, [&ros_scanner_node]() { ros_scanner_node.run(); });
-  ASSERT_BARRIER_OPENS(start_barrier, DEFAULT_TIMEOUT) << "Scanner start was not called";
-
-  ros_scanner_node.scanner_.invokeLaserScanCallback(createValidLaserScan(first_zone));
-  zoneset_topic_barrier.waitTillRelease(DEFAULT_TIMEOUT);
-
-  ros_scanner_node.terminate();
-  loop.wait_for(LOOP_END_TIMEOUT);
-}
-
 TEST_F(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserScan)
 {
   const std::string prefix = "scanner";

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -283,7 +283,7 @@ TEST_F(RosScannerNodeTests, shouldReceiveLatchedActiveZonesetMsg)
 
   util::Barrier zoneset_topic_barrier;
   SubscriberMock subscriber(nh_priv_);
-  EXPECT_CALL(subscriber, zone_callback(AllOf(isLatched(), messageEQ(createActiveZonesetMsg(first_zone)))))
+  EXPECT_CALL(subscriber, zone_callback(messageEQ(createActiveZonesetMsg(first_zone))))
       .WillOnce(OpenBarrier(&zoneset_topic_barrier));
 
   std::future<void> loop = std::async(std::launch::async, [&ros_scanner_node]() { ros_scanner_node.run(); });


### PR DESCRIPTION
## Description

Removes the latched flag from active_zoneset topic since internally it does not hold back similar states anyway.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests

</details>
