### PR TITLE
Fix hwtest_scan_range for angles which get rounded

### DIFF
--- a/test/hw_tests/config/big_resolution.yaml
+++ b/test/hw_tests/config/big_resolution.yaml
@@ -3,6 +3,6 @@ host_udp_port_control: 55116
 tf_prefix: laser_1
 angle_start: deg(-137.4)
 angle_end: deg(137.4)
-resolution: deg(1.0)
+resolution: 0.1
 intensities: false
 fragmented_scans: false

--- a/test/hw_tests/config/subrange.yaml
+++ b/test/hw_tests/config/subrange.yaml
@@ -1,8 +1,8 @@
 host_udp_port_data: 55003
 host_udp_port_control: 55116
 name: laser_1
-angle_start: deg(-100.)
-angle_end: deg(100.)
+angle_start: -1.2
+angle_end: 1.2
 resolution: deg(0.1)
 intensities: false
 fragmented_scans: false

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -25,7 +25,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
   <rosparam ns="laser_1" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
 
-  <test test-name="scan_range" pkg="psen_scan_v2" type="hwtest_scan_range.py">
+  <!-- The test-name attribute is used for recording the results (see see http://wiki.ros.org/roslaunch/XML/test).
+       The result will get overwritten if we don't choose a unique name -->
+  <arg name="test_name_suffix" value="$(eval config.split('.')[0])" />
+
+  <test test-name="scan_range__config_$(arg test_name_suffix)" pkg="psen_scan_v2" type="hwtest_scan_range.py">
     <rosparam command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
   </test>
 </launch>

--- a/test/hw_tests/hwtest_scan_range.test
+++ b/test/hw_tests/hwtest_scan_range.test
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
   <rosparam ns="laser_1" command="load" file="$(find psen_scan_v2)/test/hw_tests/config/$(arg config)" />
 
-  <!-- The test-name attribute is used for recording the results (see see http://wiki.ros.org/roslaunch/XML/test).
+  <!-- The test-name attribute is used for recording the results (see http://wiki.ros.org/roslaunch/XML/test).
        The result will get overwritten if we don't choose a unique name -->
   <arg name="test_name_suffix" value="$(eval config.split('.')[0])" />
 


### PR DESCRIPTION
## Description

Observed in #270: the `hwtest_scan_range` relied on the input angles/resolution being multiple of tenth degrees.

**Addition**: Fix problem that test result gets overwritten by runs with different config. This led to false test results reported by the PilzHardwareTestBot, see comments below.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] Copyright headers
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests

</details>
