### PR TITLE
Unify SubscriberMocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package psen_scan_v2
 
 Forthcoming
 -----------
+* Unify SubscriberMocks
 * Apply clang-tidy fixes to header-files. Fix #277
 * Remove latched flag from active zoneset topic
 * Remove unrelated parameter DEFAULT_X_AXIS_ROTATION from standalone

--- a/test/hw_tests/hwtest_zoneset_switching.cpp
+++ b/test/hw_tests/hwtest_zoneset_switching.cpp
@@ -28,6 +28,7 @@
 #include "psen_scan_v2_standalone/util/async_barrier.h"
 
 #include "psen_scan_v2/ros_integrationtest_helper.h"
+#include "psen_scan_v2/subscriber_mock.h"
 
 namespace psen_scan_v2_test
 {

--- a/test/hw_tests/hwtest_zoneset_switching.cpp
+++ b/test/hw_tests/hwtest_zoneset_switching.cpp
@@ -55,7 +55,7 @@ public:
     pub_relay_cmd_ = nh_.advertise<std_msgs::Byte>("/relay_cmd", 1);
     setScannerZoneSet(ZONE_ZERO_CMD);
     util::Barrier zone_zero_barrier;
-    SubscriberMock2<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", QUEUE_SIZE };
+    SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", QUEUE_SIZE };
     EXPECT_CALL(sm, callback(createActiveZonesetMsg(0))).Times(AnyNumber()).WillOnce(OpenBarrier(&zone_zero_barrier));
     zone_zero_barrier.waitTillRelease(DEFAULT_TIMEOUT);
   }
@@ -85,7 +85,7 @@ TEST_F(ActiveZonesetSwitchTests, shouldPublishChangedZonesetIfIOChanges)
   util::Barrier zone_zero_barrier;
   util::Barrier zone_one_barrier;
 
-  SubscriberMock2<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", 1 };
+  SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", 1 };
   {
     ::testing::InSequence s;
     EXPECT_CALL(sm, callback(createActiveZonesetMsg(0))).Times(AnyNumber()).WillOnce(OpenBarrier(&zone_zero_barrier));

--- a/test/hw_tests/hwtest_zoneset_switching.cpp
+++ b/test/hw_tests/hwtest_zoneset_switching.cpp
@@ -47,18 +47,16 @@ std_msgs::UInt8 createActiveZonesetMsg(const uint8_t active_zoneset)
 class SubscriberMock
 {
 public:
-  SubscriberMock(ros::NodeHandle& nh);
+  SubscriberMock(ros::NodeHandle& nh)
+  {
+    subscriber_ = nh.subscribe("/laser_1/active_zoneset", 1, &SubscriberMock::callback, this);
+  }
 
   MOCK_METHOD1(callback, void(const std_msgs::UInt8& msg));
 
 private:
   ros::Subscriber subscriber_;
 };
-
-inline SubscriberMock::SubscriberMock(ros::NodeHandle& nh)
-{
-  subscriber_ = nh.subscribe("/laser_1/active_zoneset", 1, &SubscriberMock::callback, this);
-}
 
 class ActiveZonesetSwitchTests : public ::testing::Test
 {

--- a/test/hw_tests/hwtest_zoneset_switching.cpp
+++ b/test/hw_tests/hwtest_zoneset_switching.cpp
@@ -48,6 +48,7 @@ std_msgs::UInt8 createActiveZonesetMsg(const uint8_t active_zoneset)
 }
 
 static constexpr int QUEUE_SIZE{ 1 };
+const std::string ACTIVE_ZONESET_TOPICNAME{ "/laser_1/active_zoneset" };
 class ActiveZonesetSwitchTests : public ::testing::Test
 {
 public:
@@ -56,7 +57,7 @@ public:
     pub_relay_cmd_ = nh_.advertise<std_msgs::Byte>("/relay_cmd", 1);
     setScannerZoneSet(ZONE_ZERO_CMD);
     util::Barrier zone_zero_barrier;
-    SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", QUEUE_SIZE };
+    SubscriberMock<std_msgs::UInt8> sm{ nh_, ACTIVE_ZONESET_TOPICNAME, QUEUE_SIZE };
     EXPECT_CALL(sm, callback(createActiveZonesetMsg(0))).Times(AnyNumber()).WillOnce(OpenBarrier(&zone_zero_barrier));
     zone_zero_barrier.waitTillRelease(DEFAULT_TIMEOUT);
   }
@@ -86,7 +87,7 @@ TEST_F(ActiveZonesetSwitchTests, shouldPublishChangedZonesetIfIOChanges)
   util::Barrier zone_zero_barrier;
   util::Barrier zone_one_barrier;
 
-  SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", QUEUE_SIZE };
+  SubscriberMock<std_msgs::UInt8> sm{ nh_, ACTIVE_ZONESET_TOPICNAME, QUEUE_SIZE };
   {
     ::testing::InSequence s;
     EXPECT_CALL(sm, callback(createActiveZonesetMsg(0))).Times(AnyNumber()).WillOnce(OpenBarrier(&zone_zero_barrier));

--- a/test/hw_tests/hwtest_zoneset_switching.cpp
+++ b/test/hw_tests/hwtest_zoneset_switching.cpp
@@ -46,7 +46,7 @@ std_msgs::UInt8 createActiveZonesetMsg(const uint8_t active_zoneset)
   return zone;
 }
 
-static constexpr int QUEUE_SIZE{ 10 };
+static constexpr int QUEUE_SIZE{ 1 };
 class ActiveZonesetSwitchTests : public ::testing::Test
 {
 public:
@@ -85,7 +85,7 @@ TEST_F(ActiveZonesetSwitchTests, shouldPublishChangedZonesetIfIOChanges)
   util::Barrier zone_zero_barrier;
   util::Barrier zone_one_barrier;
 
-  SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", 1 };
+  SubscriberMock<std_msgs::UInt8> sm{ nh_, "/laser_1/active_zoneset", QUEUE_SIZE };
   {
     ::testing::InSequence s;
     EXPECT_CALL(sm, callback(createActiveZonesetMsg(0))).Times(AnyNumber()).WillOnce(OpenBarrier(&zone_zero_barrier));

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -73,6 +73,22 @@ MATCHER_P(messageEQ, expected_msg, "")
   return expected_msg == *actual_msg;
 }
 
+// template <String topicName, int queueSize>
+template <typename T>
+class SubscriberMock2
+{
+public:
+  SubscriberMock2(ros::NodeHandle& nh, std::string topicName, int queueSize)
+  {
+    subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock2::callback, this);
+  }
+
+  MOCK_METHOD1_T(callback, void(const T& t));
+
+private:
+  ros::Subscriber subscriber_;
+};
+
 }  // namespace psen_scan_v2_test
 
 #endif  // PSEN_SCAN_V2_ROS_INTEGRATIONTEST_HELPER_H

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -24,6 +24,10 @@
 
 #include <ros/master.h>
 
+#include <visualization_msgs/Marker.h>
+
+#include "psen_scan_v2/subscriber_mock.h"
+
 using namespace std::chrono_literals;
 
 namespace psen_scan_v2_test
@@ -71,6 +75,25 @@ MATCHER_P(messageEQ, expected_msg, "")
 {
   auto actual_msg = arg.getMessage();
   return expected_msg == *actual_msg;
+}
+
+bool isConnected(SubscriberMock<visualization_msgs::MarkerConstPtr>& subscriber,
+                 const ros::Duration& timeout = ros::Duration(3.0))
+{
+  const auto start_time = ros::Time::now();
+  while (ros::ok())
+  {
+    if (subscriber.getSubscriber().getNumPublishers() > 0)
+    {
+      return true;
+    }
+    if ((ros::Time::now() - start_time) > timeout)
+    {
+      return false;
+    }
+    ros::Duration(0.1).sleep();
+  }
+  return false;
 }
 
 }  // namespace psen_scan_v2_test

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -73,26 +73,6 @@ MATCHER_P(messageEQ, expected_msg, "")
   return expected_msg == *actual_msg;
 }
 
-template <typename T>
-class SubscriberMock
-{
-public:
-  SubscriberMock(ros::NodeHandle& nh, std::string topicName, int queueSize)
-  {
-    subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock::callback, this);
-  }
-
-  MOCK_METHOD1_T(callback, void(const T& msg));
-
-  ros::Subscriber getSubscriber()
-  {
-    return subscriber_;
-  }
-
-private:
-  ros::Subscriber subscriber_;
-};
-
 }  // namespace psen_scan_v2_test
 
 #endif  // PSEN_SCAN_V2_ROS_INTEGRATIONTEST_HELPER_H

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -85,6 +85,11 @@ public:
 
   MOCK_METHOD1_T(callback, void(const T& t));
 
+  ros::Subscriber getSubscriber()
+  {
+    return subscriber_;
+  }
+
 private:
   ros::Subscriber subscriber_;
 };

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -75,12 +75,12 @@ MATCHER_P(messageEQ, expected_msg, "")
 
 // template <String topicName, int queueSize>
 template <typename T>
-class SubscriberMock2
+class SubscriberMock
 {
 public:
-  SubscriberMock2(ros::NodeHandle& nh, std::string topicName, int queueSize)
+  SubscriberMock(ros::NodeHandle& nh, std::string topicName, int queueSize)
   {
-    subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock2::callback, this);
+    subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock::callback, this);
   }
 
   MOCK_METHOD1_T(callback, void(const T& t));

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -83,7 +83,7 @@ public:
     subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock::callback, this);
   }
 
-  MOCK_METHOD1_T(callback, void(const T& t));
+  MOCK_METHOD1_T(callback, void(const T& msg));
 
   ros::Subscriber getSubscriber()
   {

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -73,7 +73,6 @@ MATCHER_P(messageEQ, expected_msg, "")
   return expected_msg == *actual_msg;
 }
 
-// template <String topicName, int queueSize>
 template <typename T>
 class SubscriberMock
 {

--- a/test/include/psen_scan_v2/subscriber_mock.h
+++ b/test/include/psen_scan_v2/subscriber_mock.h
@@ -21,8 +21,6 @@
 
 #include <ros/master.h>
 
-using namespace std::chrono_literals;
-
 namespace psen_scan_v2_test
 {
 template <typename T>

--- a/test/include/psen_scan_v2/subscriber_mock.h
+++ b/test/include/psen_scan_v2/subscriber_mock.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Pilz GmbH & Co. KG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#ifndef PSEN_SCAN_V2_SUBSCRIBER_MOCK_H
+#define PSEN_SCAN_V2_SUBSCRIBER_MOCK_H
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <ros/master.h>
+
+using namespace std::chrono_literals;
+
+namespace psen_scan_v2_test
+{
+template <typename T>
+class SubscriberMock
+{
+public:
+  SubscriberMock(ros::NodeHandle& nh, std::string topicName, int queueSize)
+  {
+    subscriber_ = nh.subscribe(topicName, queueSize, &SubscriberMock::callback, this);
+  }
+
+  MOCK_METHOD1_T(callback, void(const T& msg));
+
+  ros::Subscriber getSubscriber()
+  {
+    return subscriber_;
+  }
+
+private:
+  ros::Subscriber subscriber_;
+};
+
+}  // namespace psen_scan_v2_test
+
+#endif  // PSEN_SCAN_V2_SUBSCRIBER_MOCK_H

--- a/test/integration_tests/integrationtest_active_zoneset_node.cpp
+++ b/test/integration_tests/integrationtest_active_zoneset_node.cpp
@@ -69,25 +69,6 @@ MATCHER(hasAddAction, "")
   return arg->action == visualization_msgs::Marker::ADD;
 }
 
-bool isConnected(SubscriberMock<visualization_msgs::MarkerConstPtr>& subscriber,
-                 const ros::Duration& timeout = ros::Duration(3.0))
-{
-  const auto start_time = ros::Time::now();
-  while (ros::ok())
-  {
-    if (subscriber.getSubscriber().getNumPublishers() > 0)
-    {
-      return true;
-    }
-    if ((ros::Time::now() - start_time) > timeout)
-    {
-      return false;
-    }
-    ros::Duration(0.1).sleep();
-  }
-  return false;
-}
-
 static constexpr int QUEUE_SIZE{ 10 };
 
 #if (FMT_VERSION >= 60000 && FMT_VERSION < 70100)

--- a/test/integration_tests/integrationtest_active_zoneset_node.cpp
+++ b/test/integration_tests/integrationtest_active_zoneset_node.cpp
@@ -67,7 +67,7 @@ MATCHER(hasAddAction, "")
   return arg->action == visualization_msgs::Marker::ADD;
 }
 
-bool isConnected(SubscriberMock2<visualization_msgs::MarkerConstPtr>& subscriber,
+bool isConnected(SubscriberMock<visualization_msgs::MarkerConstPtr>& subscriber,
                  const ros::Duration& timeout = ros::Duration(3.0))
 {
   const auto start_time = ros::Time::now();
@@ -112,7 +112,7 @@ public:
   ::testing::AssertionResult switchToInvalidActiveZoneAfterSetup();
 
 public:
-  std::unique_ptr<SubscriberMock2<visualization_msgs::MarkerConstPtr>> marker_sub_mock_;
+  std::unique_ptr<SubscriberMock<visualization_msgs::MarkerConstPtr>> marker_sub_mock_;
   ros::NodeHandle nh_;
   ros::Publisher pub_active_;
 };
@@ -125,14 +125,14 @@ void ActiveZonesetNodeTest::SetUp()
   ASSERT_TRUE(resetActiveZoneNode());
 
   // initialize here to avoid traffic of above reset
-  marker_sub_mock_.reset(new SubscriberMock2<visualization_msgs::MarkerConstPtr>{
+  marker_sub_mock_.reset(new SubscriberMock<visualization_msgs::MarkerConstPtr>{
       nh_, "/test_ns_laser_1/active_zoneset_marker", QUEUE_SIZE });
   ASSERT_TRUE(isConnected(*marker_sub_mock_));
 }
 
 ::testing::AssertionResult ActiveZonesetNodeTest::switchToInvalidActiveZoneAfterSetup()
 {
-  SubscriberMock2<visualization_msgs::MarkerConstPtr> invalid_marker_mock(
+  SubscriberMock<visualization_msgs::MarkerConstPtr> invalid_marker_mock(
       nh_, "/test_ns_laser_1/active_zoneset_marker", QUEUE_SIZE);
   if (!isConnected(invalid_marker_mock))
   {
@@ -161,7 +161,7 @@ void ActiveZonesetNodeTest::sendActiveZone(uint8_t zone)
 
 ::testing::AssertionResult ActiveZonesetNodeTest::resetActiveZoneNode()
 {
-  SubscriberMock2<visualization_msgs::MarkerConstPtr> reset_marker_mock(
+  SubscriberMock<visualization_msgs::MarkerConstPtr> reset_marker_mock(
       nh_, "/test_ns_laser_1/active_zoneset_marker", QUEUE_SIZE);
 
   if (!isConnected(reset_marker_mock))

--- a/test/integration_tests/integrationtest_active_zoneset_node.cpp
+++ b/test/integration_tests/integrationtest_active_zoneset_node.cpp
@@ -113,10 +113,12 @@ void ActiveZonesetNodeTest::SetUp()
   ASSERT_TRUE(isConnected(*marker_sub_mock_));
 }
 
+const std::string ACTIVE_ZONESET_MARKER_TOPICNAME{ "/test_ns_laser_1/active_zoneset_marker" };
+
 ::testing::AssertionResult ActiveZonesetNodeTest::switchToInvalidActiveZoneAfterSetup()
 {
   SubscriberMock<visualization_msgs::MarkerConstPtr> invalid_marker_mock(
-      nh_, "/test_ns_laser_1/active_zoneset_marker", QUEUE_SIZE);
+      nh_, ACTIVE_ZONESET_MARKER_TOPICNAME, QUEUE_SIZE);
   if (!isConnected(invalid_marker_mock))
   {
     return ::testing::AssertionFailure() << "Could not connect with subscriber on marker topic.";
@@ -145,7 +147,7 @@ void ActiveZonesetNodeTest::sendActiveZone(uint8_t zone)
 ::testing::AssertionResult ActiveZonesetNodeTest::resetActiveZoneNode()
 {
   SubscriberMock<visualization_msgs::MarkerConstPtr> reset_marker_mock(
-      nh_, "/test_ns_laser_1/active_zoneset_marker", QUEUE_SIZE);
+      nh_, ACTIVE_ZONESET_MARKER_TOPICNAME, QUEUE_SIZE);
 
   if (!isConnected(reset_marker_mock))
   {

--- a/test/integration_tests/integrationtest_active_zoneset_node.cpp
+++ b/test/integration_tests/integrationtest_active_zoneset_node.cpp
@@ -29,6 +29,8 @@
 #include <std_msgs/UInt8.h>
 
 #include "psen_scan_v2/ros_integrationtest_helper.h"
+#include "psen_scan_v2/subscriber_mock.h"
+
 #include "psen_scan_v2_standalone/util/async_barrier.h"
 #include "psen_scan_v2_standalone/util/gmock_expectations.h"
 

--- a/test/integration_tests/integrationtest_config_server_node.cpp
+++ b/test/integration_tests/integrationtest_config_server_node.cpp
@@ -162,7 +162,7 @@ TEST_F(ConfigServerNodeTest, shouldAdvertiseZonesetTopic)
 TEST_F(ConfigServerNodeTest, shouldPublishLatchedOnZonesetTopic)
 {
   ros::NodeHandle nh;
-  SubscriberMock2<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
+  SubscriberMock<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
       nh, "/test_ns_laser_1/zoneconfiguration", 10);
   util::Barrier topic_received_barrier;
 
@@ -174,7 +174,7 @@ TEST_F(ConfigServerNodeTest, shouldPublishLatchedOnZonesetTopic)
 TEST_F(ConfigServerNodeTest, shouldPublishMessageMatchingExpectedZoneSetConfig)
 {
   ros::NodeHandle nh;
-  SubscriberMock2<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
+  SubscriberMock<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
       nh, "/test_ns_laser_1/zoneconfiguration", 10);
   util::Barrier msg_received_barrier;
 

--- a/test/integration_tests/integrationtest_config_server_node.cpp
+++ b/test/integration_tests/integrationtest_config_server_node.cpp
@@ -115,22 +115,6 @@ ZoneSetConfiguration readSingleMsgFromBagFile(const std::string& filepath, const
   bag.close();
   return *msg;
 }
-
-class SubscriberMock
-{
-public:
-  SubscriberMock()
-  {
-    subscriber_ = nh_.subscribe("/test_ns_laser_1/zoneconfiguration", 10, &SubscriberMock::callback, this);
-  }
-
-  MOCK_METHOD1(callback, void(const ros::MessageEvent<ZoneSetConfiguration const>& event));
-
-private:
-  ros::NodeHandle nh_;
-  ros::Subscriber subscriber_;
-};
-
 class ConfigServerNodeTest : public testing::Test
 {
 public:
@@ -177,7 +161,9 @@ TEST_F(ConfigServerNodeTest, shouldAdvertiseZonesetTopic)
 
 TEST_F(ConfigServerNodeTest, shouldPublishLatchedOnZonesetTopic)
 {
-  SubscriberMock subscriber_mock;
+  ros::NodeHandle nh;
+  SubscriberMock2<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
+      nh, "/test_ns_laser_1/zoneconfiguration", 10);
   util::Barrier topic_received_barrier;
 
   EXPECT_CALL(subscriber_mock, callback(isLatched())).WillOnce(OpenBarrier(&topic_received_barrier));
@@ -187,7 +173,9 @@ TEST_F(ConfigServerNodeTest, shouldPublishLatchedOnZonesetTopic)
 
 TEST_F(ConfigServerNodeTest, shouldPublishMessageMatchingExpectedZoneSetConfig)
 {
-  SubscriberMock subscriber_mock;
+  ros::NodeHandle nh;
+  SubscriberMock2<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
+      nh, "/test_ns_laser_1/zoneconfiguration", 10);
   util::Barrier msg_received_barrier;
 
   EXPECT_CALL(subscriber_mock, callback(msgZoneSetConfigEQ(expectedZoneSetConfig())))

--- a/test/integration_tests/integrationtest_config_server_node.cpp
+++ b/test/integration_tests/integrationtest_config_server_node.cpp
@@ -34,6 +34,7 @@
 #include "psen_scan_v2/zoneset_msg_builder.h"
 
 #include "psen_scan_v2/ros_integrationtest_helper.h"
+#include "psen_scan_v2/subscriber_mock.h"
 
 #include "psen_scan_v2_standalone/util/async_barrier.h"
 #include "psen_scan_v2_standalone/util/matchers_and_actions.h"

--- a/test/integration_tests/integrationtest_config_server_node.cpp
+++ b/test/integration_tests/integrationtest_config_server_node.cpp
@@ -154,17 +154,21 @@ private:
   ZoneSetConfiguration zoneset_config_;
 };
 
+const std::string ZONE_CONFIGURATION_TOPICNAME{ "/test_ns_laser_1/zoneconfiguration" };
+
 TEST_F(ConfigServerNodeTest, shouldAdvertiseZonesetTopic)
 {
   // Set param on server
-  EXPECT_TRUE(TopicExists("/test_ns_laser_1/zoneconfiguration"));
+  EXPECT_TRUE(TopicExists(ZONE_CONFIGURATION_TOPICNAME));
 }
+
+static constexpr int QUEUE_SIZE{ 10 };
 
 TEST_F(ConfigServerNodeTest, shouldPublishLatchedOnZonesetTopic)
 {
   ros::NodeHandle nh;
   SubscriberMock<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
-      nh, "/test_ns_laser_1/zoneconfiguration", 10);
+      nh, ZONE_CONFIGURATION_TOPICNAME, QUEUE_SIZE);
   util::Barrier topic_received_barrier;
 
   EXPECT_CALL(subscriber_mock, callback(isLatched())).WillOnce(OpenBarrier(&topic_received_barrier));
@@ -176,7 +180,7 @@ TEST_F(ConfigServerNodeTest, shouldPublishMessageMatchingExpectedZoneSetConfig)
 {
   ros::NodeHandle nh;
   SubscriberMock<ros::MessageEvent<ZoneSetConfiguration const>> subscriber_mock(
-      nh, "/test_ns_laser_1/zoneconfiguration", 10);
+      nh, ZONE_CONFIGURATION_TOPICNAME, QUEUE_SIZE);
   util::Barrier msg_received_barrier;
 
   EXPECT_CALL(subscriber_mock, callback(msgZoneSetConfigEQ(expectedZoneSetConfig())))

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -206,7 +206,7 @@ TEST_F(RosScannerNodeTests, shouldPublishScansWhenLaserScanCallbackIsInvoked)
   ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock2<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
+  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
   EXPECT_CALL(subscriber, callback(::testing::_)).WillOnce(Return()).WillOnce(OpenBarrier(&scan_topic_barrier));
 
   util::Barrier start_barrier;
@@ -231,7 +231,7 @@ TEST_F(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInv
   const uint8_t second_zone{ 4 };
 
   util::Barrier zoneset_topic_barrier;
-  SubscriberMock2<ros::MessageEvent<std_msgs::UInt8 const>> subscriber(nh_priv_, "active_zoneset", QUEUE_SIZE);
+  SubscriberMock<ros::MessageEvent<std_msgs::UInt8 const>> subscriber(nh_priv_, "active_zoneset", QUEUE_SIZE);
   {
     InSequence s;
     EXPECT_CALL(subscriber, callback(messageEQ(createActiveZonesetMsg(first_zone)))).Times(1);
@@ -262,7 +262,7 @@ TEST_F(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserSca
   setDefaultActions(ros_scanner_node.scanner_, start_barrier);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock2<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
+  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
   const auto scan = createValidLaserScan();
   EXPECT_CALL(subscriber, callback(toLaserScanMsg(scan, prefix, 1.0 /*x_axis_rotation*/)))
       .WillOnce(OpenBarrier(&scan_topic_barrier));

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -202,12 +202,15 @@ TEST_F(RosScannerNodeTests, shouldProvideActiveZonesetTopic)
   loop.wait_for(LOOP_END_TIMEOUT);
 }
 
+const std::string SCAN_TOPICNAME{ "scan" };
+
 TEST_F(RosScannerNodeTests, shouldPublishScansWhenLaserScanCallbackIsInvoked)
 {
-  ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
+  ROSScannerNodeT<ScannerMock> ros_scanner_node(
+      nh_priv_, SCAN_TOPICNAME, "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
+  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, SCAN_TOPICNAME, QUEUE_SIZE);
   EXPECT_CALL(subscriber, callback(::testing::_)).WillOnce(Return()).WillOnce(OpenBarrier(&scan_topic_barrier));
 
   util::Barrier start_barrier;
@@ -224,15 +227,18 @@ TEST_F(RosScannerNodeTests, shouldPublishScansWhenLaserScanCallbackIsInvoked)
   loop.wait_for(LOOP_END_TIMEOUT);
 }
 
+const std::string ACTIVE_ZONESET_TOPICNAME{ "active_zoneset" };
+
 TEST_F(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInvoked)
 {
-  ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
+  ROSScannerNodeT<ScannerMock> ros_scanner_node(
+      nh_priv_, SCAN_TOPICNAME, "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
 
   const uint8_t first_zone{ 2 };
   const uint8_t second_zone{ 4 };
 
   util::Barrier zoneset_topic_barrier;
-  SubscriberMock<ros::MessageEvent<std_msgs::UInt8 const>> subscriber(nh_priv_, "active_zoneset", QUEUE_SIZE);
+  SubscriberMock<ros::MessageEvent<std_msgs::UInt8 const>> subscriber(nh_priv_, ACTIVE_ZONESET_TOPICNAME, QUEUE_SIZE);
   {
     InSequence s;
     EXPECT_CALL(subscriber, callback(messageEQ(createActiveZonesetMsg(first_zone)))).Times(1);
@@ -257,13 +263,14 @@ TEST_F(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInv
 TEST_F(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserScan)
 {
   const std::string prefix = "scanner";
-  ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", prefix, 1.0 /*x_axis_rotation*/, scanner_config_);
+  ROSScannerNodeT<ScannerMock> ros_scanner_node(
+      nh_priv_, SCAN_TOPICNAME, prefix, 1.0 /*x_axis_rotation*/, scanner_config_);
 
   util::Barrier start_barrier;
   setDefaultActions(ros_scanner_node.scanner_, start_barrier);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
+  SubscriberMock<sensor_msgs::LaserScan> subscriber(nh_priv_, SCAN_TOPICNAME, QUEUE_SIZE);
   const auto scan = createValidLaserScan();
   EXPECT_CALL(subscriber, callback(toLaserScanMsg(scan, prefix, 1.0 /*x_axis_rotation*/)))
       .WillOnce(OpenBarrier(&scan_topic_barrier));
@@ -281,7 +288,8 @@ TEST_F(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserSca
 
 TEST_F(RosScannerNodeTests, shouldWaitWhenStopRequestResponseIsMissing)
 {
-  ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
+  ROSScannerNodeT<ScannerMock> ros_scanner_node(
+      nh_priv_, SCAN_TOPICNAME, "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
 
   util::Barrier start_barrier;
   ON_CALL(ros_scanner_node.scanner_, start())

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -40,6 +40,7 @@
 
 #include "psen_scan_v2/scanner_mock.h"
 #include "psen_scan_v2/ros_integrationtest_helper.h"
+#include "psen_scan_v2/subscriber_mock.h"
 
 using namespace psen_scan_v2;
 using namespace psen_scan_v2_standalone;

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -63,26 +63,6 @@ ACTION(ReturnReadyVoidFuture)
 }
 
 static constexpr int QUEUE_SIZE{ 10 };
-
-class SubscriberMock
-{
-public:
-  SubscriberMock(ros::NodeHandle& nh);
-
-  MOCK_METHOD1(scan_callback, void(const sensor_msgs::LaserScan& msg));
-  MOCK_METHOD1(zone_callback, void(const ros::MessageEvent<std_msgs::UInt8 const>& event));
-
-private:
-  ros::Subscriber scan_subscriber_;
-  ros::Subscriber zone_subscriber_;
-};
-
-inline SubscriberMock::SubscriberMock(ros::NodeHandle& nh)
-{
-  scan_subscriber_ = nh.subscribe("scan", QUEUE_SIZE, &SubscriberMock::scan_callback, this);
-  zone_subscriber_ = nh.subscribe("active_zoneset", QUEUE_SIZE, &SubscriberMock::zone_callback, this);
-}
-
 static const std::string HOST_IP{ "127.0.0.1" };
 static constexpr int HOST_UDP_PORT_DATA{ 50505 };
 static constexpr int HOST_UDP_PORT_CONTROL{ 55055 };
@@ -226,8 +206,8 @@ TEST_F(RosScannerNodeTests, shouldPublishScansWhenLaserScanCallbackIsInvoked)
   ROSScannerNodeT<ScannerMock> ros_scanner_node(nh_priv_, "scan", "scanner", 1.0 /*x_axis_rotation*/, scanner_config_);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock subscriber(nh_priv_);
-  EXPECT_CALL(subscriber, scan_callback(::testing::_)).WillOnce(Return()).WillOnce(OpenBarrier(&scan_topic_barrier));
+  SubscriberMock2<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
+  EXPECT_CALL(subscriber, callback(::testing::_)).WillOnce(Return()).WillOnce(OpenBarrier(&scan_topic_barrier));
 
   util::Barrier start_barrier;
   setDefaultActions(ros_scanner_node.scanner_, start_barrier);
@@ -251,11 +231,11 @@ TEST_F(RosScannerNodeTests, shouldPublishActiveZonesetWhenLaserScanCallbackIsInv
   const uint8_t second_zone{ 4 };
 
   util::Barrier zoneset_topic_barrier;
-  SubscriberMock subscriber(nh_priv_);
+  SubscriberMock2<ros::MessageEvent<std_msgs::UInt8 const>> subscriber(nh_priv_, "active_zoneset", QUEUE_SIZE);
   {
     InSequence s;
-    EXPECT_CALL(subscriber, zone_callback(messageEQ(createActiveZonesetMsg(first_zone)))).Times(1);
-    EXPECT_CALL(subscriber, zone_callback(messageEQ(createActiveZonesetMsg(second_zone))))
+    EXPECT_CALL(subscriber, callback(messageEQ(createActiveZonesetMsg(first_zone)))).Times(1);
+    EXPECT_CALL(subscriber, callback(messageEQ(createActiveZonesetMsg(second_zone))))
         .WillOnce(OpenBarrier(&zoneset_topic_barrier));
   }
 
@@ -282,9 +262,9 @@ TEST_F(RosScannerNodeTests, shouldPublishScanEqualToConversionOfSuppliedLaserSca
   setDefaultActions(ros_scanner_node.scanner_, start_barrier);
 
   util::Barrier scan_topic_barrier;
-  SubscriberMock subscriber(nh_priv_);
+  SubscriberMock2<sensor_msgs::LaserScan> subscriber(nh_priv_, "scan", QUEUE_SIZE);
   const auto scan = createValidLaserScan();
-  EXPECT_CALL(subscriber, scan_callback(toLaserScanMsg(scan, prefix, 1.0 /*x_axis_rotation*/)))
+  EXPECT_CALL(subscriber, callback(toLaserScanMsg(scan, prefix, 1.0 /*x_axis_rotation*/)))
       .WillOnce(OpenBarrier(&scan_topic_barrier));
 
   std::future<void> loop = std::async(std::launch::async, [&ros_scanner_node]() { ros_scanner_node.run(); });


### PR DESCRIPTION
## Description

These changes unify three SubScriberMocks and move the unified class to ros_integrationstest_helper.h



### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] ~Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))~
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
