### PR TITLE
Refactor naming of getters and setters

### DIFF
--- a/include/psen_scan_v2/active_zoneset_node.h
+++ b/include/psen_scan_v2/active_zoneset_node.h
@@ -57,7 +57,7 @@ public:
 private:
   void updateMarkers();
   bool isAllInformationAvailable() const;
-  ZoneSet getActiveZoneset() const;
+  ZoneSet activeZoneset() const;
   void deleteLastMarkers();
   void addMarkers(std::vector<visualization_msgs::Marker>& new_markers);
   bool containLastMarkers(const std::vector<visualization_msgs::Marker>& new_markers);

--- a/include/psen_scan_v2/active_zoneset_node.h
+++ b/include/psen_scan_v2/active_zoneset_node.h
@@ -57,7 +57,11 @@ public:
 private:
   void updateMarkers();
   bool isAllInformationAvailable() const;
+
+  /*! deprecated: use ZoneSet activeZoneset() const instead */
+  [[deprecated("use ZoneSet activeZoneset() const instead")]] ZoneSet getActiveZoneset() const;
   ZoneSet activeZoneset() const;
+
   void deleteLastMarkers();
   void addMarkers(std::vector<visualization_msgs::Marker>& new_markers);
   bool containLastMarkers(const std::vector<visualization_msgs::Marker>& new_markers);

--- a/include/psen_scan_v2/laserscan_ros_conversions.h
+++ b/include/psen_scan_v2/laserscan_ros_conversions.h
@@ -30,28 +30,27 @@ sensor_msgs::LaserScan toLaserScanMsg(const LaserScan& laserscan,
                                       const double x_axis_rotation)
 {
   sensor_msgs::LaserScan ros_message;
-  if (laserscan.getTimestamp() < 0)
+  if (laserscan.timestamp() < 0)
   {
-    throw std::invalid_argument("Laserscan message has an invalid timestamp: " +
-                                std::to_string(laserscan.getTimestamp()));
+    throw std::invalid_argument("Laserscan message has an invalid timestamp: " + std::to_string(laserscan.timestamp()));
   }
-  ros_message.header.stamp = ros::Time{}.fromNSec(laserscan.getTimestamp());
+  ros_message.header.stamp = ros::Time{}.fromNSec(laserscan.timestamp());
   ros_message.header.frame_id = frame_id;
-  ros_message.angle_min = laserscan.getMinScanAngle().toRad() - x_axis_rotation;
-  ros_message.angle_max = laserscan.getMaxScanAngle().toRad() - x_axis_rotation;
-  ros_message.angle_increment = laserscan.getScanResolution().toRad();
+  ros_message.angle_min = laserscan.minScanAngle().toRad() - x_axis_rotation;
+  ros_message.angle_max = laserscan.maxScanAngle().toRad() - x_axis_rotation;
+  ros_message.angle_increment = laserscan.scanResolution().toRad();
 
-  ros_message.time_increment = configuration::TIME_PER_SCAN_IN_S / (2 * M_PI) * laserscan.getScanResolution().toRad();
+  ros_message.time_increment = configuration::TIME_PER_SCAN_IN_S / (2 * M_PI) * laserscan.scanResolution().toRad();
 
   ros_message.scan_time = configuration::TIME_PER_SCAN_IN_S;
   ros_message.range_min = configuration::RANGE_MIN_IN_M;
   ros_message.range_max = configuration::RANGE_MAX_IN_M;
 
   ros_message.ranges.insert(
-      ros_message.ranges.begin(), laserscan.getMeasurements().cbegin(), laserscan.getMeasurements().cend());
+      ros_message.ranges.begin(), laserscan.measurements().cbegin(), laserscan.measurements().cend());
 
   ros_message.intensities.insert(
-      ros_message.intensities.begin(), laserscan.getIntensities().cbegin(), laserscan.getIntensities().cend());
+      ros_message.intensities.begin(), laserscan.intensities().cbegin(), laserscan.intensities().cend());
 
   return ros_message;
 }

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -133,7 +133,7 @@ void ROSScannerNodeT<S>::laserScanCallback(const LaserScan& scan)
     pub_scan_.publish(laser_scan_msg);
 
     std_msgs::UInt8 active_zoneset;
-    active_zoneset.data = scan.getActiveZoneset();
+    active_zoneset.data = scan.activeZoneset();
     pub_zone_.publish(active_zoneset);
 
     for (const auto& io : scan.getIOStates())

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -136,7 +136,7 @@ void ROSScannerNodeT<S>::laserScanCallback(const LaserScan& scan)
     active_zoneset.data = scan.activeZoneset();
     pub_zone_.publish(active_zoneset);
 
-    for (const auto& io : scan.getIOStates())
+    for (const auto& io : scan.ioStates())
     {
       pub_io_.publish(toIOStateMsg(io, tf_prefix_, scan.timestamp()));
     }

--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -138,7 +138,7 @@ void ROSScannerNodeT<S>::laserScanCallback(const LaserScan& scan)
 
     for (const auto& io : scan.getIOStates())
     {
-      pub_io_.publish(toIOStateMsg(io, tf_prefix_, scan.getTimestamp()));
+      pub_io_.publish(toIOStateMsg(io, tf_prefix_, scan.timestamp()));
     }
   }
   // LCOV_EXCL_START

--- a/src/active_zoneset_node.cpp
+++ b/src/active_zoneset_node.cpp
@@ -82,10 +82,12 @@ ZoneSet ActiveZonesetNode::activeZoneset() const
   return zoneset_config_->zonesets.at(active_zoneset_id_->data);
 }
 
+// LCOV_EXCL_START
 ZoneSet ActiveZonesetNode::getActiveZoneset() const
 {
-  return zoneset_config_->zonesets.at(active_zoneset_id_->data);
+  return this->activeZoneset();
 }
+// LCOV_EXCL_STOP
 
 void ActiveZonesetNode::addMarkers(std::vector<visualization_msgs::Marker>& new_markers)
 {

--- a/src/active_zoneset_node.cpp
+++ b/src/active_zoneset_node.cpp
@@ -55,7 +55,7 @@ void ActiveZonesetNode::updateMarkers()
   {
     try
     {
-      auto new_markers = toMarkers(getActiveZoneset());
+      auto new_markers = toMarkers(activeZoneset());
       if (!containLastMarkers(new_markers))
       {
         deleteLastMarkers();
@@ -77,7 +77,7 @@ bool ActiveZonesetNode::isAllInformationAvailable() const
   return active_zoneset_id_.is_initialized() && zoneset_config_.is_initialized();
 }
 
-ZoneSet ActiveZonesetNode::getActiveZoneset() const
+ZoneSet ActiveZonesetNode::activeZoneset() const
 {
   return zoneset_config_->zonesets.at(active_zoneset_id_->data);
 }

--- a/src/active_zoneset_node.cpp
+++ b/src/active_zoneset_node.cpp
@@ -82,6 +82,11 @@ ZoneSet ActiveZonesetNode::activeZoneset() const
   return zoneset_config_->zonesets.at(active_zoneset_id_->data);
 }
 
+ZoneSet ActiveZonesetNode::getActiveZoneset() const
+{
+  return zoneset_config_->zonesets.at(active_zoneset_id_->data);
+}
+
 void ActiveZonesetNode::addMarkers(std::vector<visualization_msgs::Marker>& new_markers)
 {
   for (const auto& marker : new_markers)

--- a/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
+++ b/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
@@ -149,8 +149,14 @@ public:
 
   /**
    * @brief Returns local ip address of current socket connection.
+   * deprecated: use boost::asio::ip::address_v4 hostIp() instead
    */
-  boost::asio::ip::address_v4 getHostIp();
+  [[deprecated("use boost::asio::ip::address_v4 hostIp() instead")]] boost::asio::ip::address_v4 getHostIp();
+
+  /**
+   * @brief Returns local ip address of current socket connection.
+   */
+  boost::asio::ip::address_v4 hostIp();
 
 private:
   void asyncReceive(const ReceiveMode& modi);
@@ -237,6 +243,11 @@ inline void UdpClientImpl::close()
     throw CloseConnectionFailure(ex.what());
   }
   // LCOV_EXCL_STOP
+}
+
+inline boost::asio::ip::address_v4 UdpClientImpl::hostIp()
+{
+  return socket_.local_endpoint().address().to_v4();
 }
 
 inline boost::asio::ip::address_v4 UdpClientImpl::getHostIp()

--- a/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
+++ b/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
@@ -252,7 +252,7 @@ inline boost::asio::ip::address_v4 UdpClientImpl::hostIp()
 
 inline boost::asio::ip::address_v4 UdpClientImpl::getHostIp()
 {
-  return socket_.local_endpoint().address().to_v4();
+  return this->hostIp();
 }
 
 inline UdpClientImpl::~UdpClientImpl()

--- a/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
+++ b/standalone/include/psen_scan_v2_standalone/communication_layer/udp_client.h
@@ -149,12 +149,6 @@ public:
 
   /**
    * @brief Returns local ip address of current socket connection.
-   * deprecated: use boost::asio::ip::address_v4 hostIp() instead
-   */
-  [[deprecated("use boost::asio::ip::address_v4 hostIp() instead")]] boost::asio::ip::address_v4 getHostIp();
-
-  /**
-   * @brief Returns local ip address of current socket connection.
    */
   boost::asio::ip::address_v4 hostIp();
 
@@ -248,11 +242,6 @@ inline void UdpClientImpl::close()
 inline boost::asio::ip::address_v4 UdpClientImpl::hostIp()
 {
   return socket_.local_endpoint().address().to_v4();
-}
-
-inline boost::asio::ip::address_v4 UdpClientImpl::getHostIp()
-{
-  return this->hostIp();
 }
 
 inline UdpClientImpl::~UdpClientImpl()

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
@@ -155,7 +155,7 @@ public:
   /*! deprecated: use inline constexpr ByteLocation byte() const instead */
   [[deprecated("use inline constexpr ByteLocation byte() const instead")]] inline constexpr ByteLocation getByte() const
   {
-    return byte_;
+    return this->byte();
   };
 
   inline constexpr ByteLocation byte() const
@@ -166,7 +166,7 @@ public:
   /*! deprecated: use inline constexpr BitLocation bit() const instead */
   [[deprecated("use inline constexpr BitLocation bit() const instead")]] inline constexpr BitLocation getBit() const
   {
-    return bit_;
+    return this->bit();
   };
 
   inline constexpr BitLocation bit() const
@@ -202,7 +202,7 @@ public:
   [[deprecated("use constexpr configuration::ScannerId scannerId() const instead")]] constexpr configuration::ScannerId
   getScannerId() const
   {
-    return id_;
+    return this->scannerId();
   }
 
   constexpr configuration::ScannerId scannerId() const
@@ -214,7 +214,7 @@ public:
   [[deprecated("use constexpr ErrorLocation errorLocation() const instead")]] constexpr ErrorLocation
   getErrorLocation() const
   {
-    return error_location_;
+    return this->errorLocation();
   }
 
   constexpr ErrorLocation errorLocation() const
@@ -225,7 +225,7 @@ public:
   /*! deprecated: use constexpr ErrorType diagnosticCode() const instead */
   [[deprecated("use constexpr ErrorType diagnosticCode() const instead")]] constexpr ErrorType getDiagnosticCode() const
   {
-    return ERROR_BITS.at(error_location_.byte()).at(error_location_.bit());
+    return this->diagnosticCode();
   }
 
   constexpr ErrorType diagnosticCode() const

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
@@ -152,21 +152,9 @@ public:
   using BitLocation = size_t;
   constexpr ErrorLocation(const ByteLocation& byte, const BitLocation& bit) : byte_(byte), bit_(bit){};
 
-  /*! deprecated: use inline constexpr ByteLocation byte() const instead */
-  [[deprecated("use inline constexpr ByteLocation byte() const instead")]] inline constexpr ByteLocation getByte() const
-  {
-    return this->byte();
-  };
-
   inline constexpr ByteLocation byte() const
   {
     return byte_;
-  };
-
-  /*! deprecated: use inline constexpr BitLocation bit() const instead */
-  [[deprecated("use inline constexpr BitLocation bit() const instead")]] inline constexpr BitLocation getBit() const
-  {
-    return this->bit();
   };
 
   inline constexpr BitLocation bit() const
@@ -198,34 +186,14 @@ public:
 
   friend RawChunk serialize(const std::vector<diagnostic::Message>& messages);
 
-  /*! deprecated: use constexpr configuration::ScannerId scannerId() const instead */
-  [[deprecated("use constexpr configuration::ScannerId scannerId() const instead")]] constexpr configuration::ScannerId
-  getScannerId() const
-  {
-    return this->scannerId();
-  }
-
   constexpr configuration::ScannerId scannerId() const
   {
     return id_;
   }
 
-  /*! deprecated: use constexpr ErrorLocation errorLocation() const instead */
-  [[deprecated("use constexpr ErrorLocation errorLocation() const instead")]] constexpr ErrorLocation
-  getErrorLocation() const
-  {
-    return this->errorLocation();
-  }
-
   constexpr ErrorLocation errorLocation() const
   {
     return error_location_;
-  }
-
-  /*! deprecated: use constexpr ErrorType diagnosticCode() const instead */
-  [[deprecated("use constexpr ErrorType diagnosticCode() const instead")]] constexpr ErrorType getDiagnosticCode() const
-  {
-    return this->diagnosticCode();
   }
 
   constexpr ErrorType diagnosticCode() const

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
@@ -196,17 +196,39 @@ public:
   constexpr Message(const configuration::ScannerId& id, const diagnostic::ErrorLocation& location);
   constexpr bool operator==(const diagnostic::Message& rhs) const;
 
-  constexpr configuration::ScannerId getScannerId() const
+  friend RawChunk serialize(const std::vector<diagnostic::Message>& messages);
+
+  /*! deprecated: use constexpr configuration::ScannerId scannerId() const instead */
+  [[deprecated("use constexpr configuration::ScannerId scannerId() const instead")]] constexpr configuration::ScannerId
+  getScannerId() const
   {
     return id_;
   }
 
-  constexpr ErrorLocation getErrorLocation() const
+  constexpr configuration::ScannerId scannerId() const
+  {
+    return id_;
+  }
+
+  /*! deprecated: use constexpr ErrorLocation errorLocation() const instead */
+  [[deprecated("use constexpr ErrorLocation errorLocation() const instead")]] constexpr ErrorLocation
+  getErrorLocation() const
   {
     return error_location_;
   }
 
-  constexpr ErrorType getDiagnosticCode() const
+  constexpr ErrorLocation errorLocation() const
+  {
+    return error_location_;
+  }
+
+  /*! deprecated: use constexpr ErrorType diagnosticCode() const instead */
+  [[deprecated("use constexpr ErrorType diagnosticCode() const instead")]] constexpr ErrorType getDiagnosticCode() const
+  {
+    return ERROR_BITS.at(error_location_.byte()).at(error_location_.bit());
+  }
+
+  constexpr ErrorType diagnosticCode() const
   {
     return ERROR_BITS.at(error_location_.byte()).at(error_location_.bit());
   }

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/diagnostics.h
@@ -151,11 +151,25 @@ public:
   using ByteLocation = size_t;
   using BitLocation = size_t;
   constexpr ErrorLocation(const ByteLocation& byte, const BitLocation& bit) : byte_(byte), bit_(bit){};
-  inline constexpr ByteLocation getByte() const
+
+  /*! deprecated: use inline constexpr ByteLocation byte() const instead */
+  [[deprecated("use inline constexpr ByteLocation byte() const instead")]] inline constexpr ByteLocation getByte() const
   {
     return byte_;
   };
-  inline constexpr BitLocation getBit() const
+
+  inline constexpr ByteLocation byte() const
+  {
+    return byte_;
+  };
+
+  /*! deprecated: use inline constexpr BitLocation bit() const instead */
+  [[deprecated("use inline constexpr BitLocation bit() const instead")]] inline constexpr BitLocation getBit() const
+  {
+    return bit_;
+  };
+
+  inline constexpr BitLocation bit() const
   {
     return bit_;
   };
@@ -194,7 +208,7 @@ public:
 
   constexpr ErrorType getDiagnosticCode() const
   {
-    return ERROR_BITS.at(error_location_.getByte()).at(error_location_.getBit());
+    return ERROR_BITS.at(error_location_.byte()).at(error_location_.bit());
   }
 
 private:
@@ -209,8 +223,8 @@ constexpr inline Message::Message(const configuration::ScannerId& id, const Erro
 
 constexpr inline bool Message::operator==(const Message& rhs) const
 {
-  return (error_location_.getBit() == rhs.error_location_.getBit() &&
-          error_location_.getByte() == rhs.error_location_.getByte() && id_ == rhs.id_);
+  return (error_location_.bit() == rhs.error_location_.bit() && error_location_.byte() == rhs.error_location_.byte() &&
+          id_ == rhs.id_);
 }
 
 // Store ambiguous errors for additional output

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
@@ -128,7 +128,7 @@ inline LaserScan LaserScanConverter::toLaserScan(
 
   scan.measurements(measurements);
   scan.intensities(intensities);
-  scan.setIOStates(io_states);
+  scan.ioStates(io_states);
 
   return scan;
 }

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/laserscan_conversions.h
@@ -125,8 +125,9 @@ inline LaserScan LaserScanConverter::toLaserScan(
                  stamped_msgs[0].msg_.scanCounter(),
                  stamped_msgs[sorted_stamped_msgs_indices.back()].msg_.activeZoneset(),
                  timestamp);
-  scan.setMeasurements(measurements);
-  scan.setIntensities(intensities);
+
+  scan.measurements(measurements);
+  scan.intensities(intensities);
   scan.setIOStates(io_states);
 
   return scan;

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -60,8 +60,17 @@ private:
     constexpr LaserScanSettings(const ScanRange& scan_range, const util::TenthOfDegree& resolution);
 
   public:
-    constexpr const ScanRange& getScanRange() const;
-    constexpr util::TenthOfDegree getResolution() const;
+    /*! deprecated: use constexpr const ScanRange& scanRange() const instead */
+    [[deprecated("use constexpr const ScanRange& scanRange() const instead")]] constexpr const ScanRange&
+    getScanRange() const;
+
+    constexpr const ScanRange& scanRange() const;
+
+    /*! deprecated: use constexpr util::TenthOfDegree resolution() const instead */
+    [[deprecated("use constexpr util::TenthOfDegree resolution() const instead")]] constexpr util::TenthOfDegree
+    getResolution() const;
+
+    constexpr util::TenthOfDegree resolution() const;
 
   private:
     const ScanRange scan_range_{ ScanRange::createInvalidScanRange() };
@@ -102,6 +111,16 @@ constexpr Message::LaserScanSettings::LaserScanSettings(const ScanRange& scan_ra
   : scan_range_(scan_range), resolution_(resolution)
 {
 }
+
+constexpr const ScanRange& Message::LaserScanSettings::scanRange() const
+{
+  return scan_range_;
+};
+
+constexpr util::TenthOfDegree Message::LaserScanSettings::resolution() const
+{
+  return resolution_;
+};
 
 constexpr const ScanRange& Message::LaserScanSettings::getScanRange() const
 {

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -124,12 +124,12 @@ constexpr util::TenthOfDegree Message::LaserScanSettings::resolution() const
 
 constexpr const ScanRange& Message::LaserScanSettings::getScanRange() const
 {
-  return scan_range_;
+  return this->scanRange();
 };
 
 constexpr util::TenthOfDegree Message::LaserScanSettings::getResolution() const
 {
-  return resolution_;
+  return this->resolution();
 };
 
 constexpr Message::DeviceSettings::DeviceSettings(const bool diagnostics_enabled, const bool intensities_enabled)

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -60,16 +60,7 @@ private:
     constexpr LaserScanSettings(const ScanRange& scan_range, const util::TenthOfDegree& resolution);
 
   public:
-    /*! deprecated: use constexpr const ScanRange& scanRange() const instead */
-    [[deprecated("use constexpr const ScanRange& scanRange() const instead")]] constexpr const ScanRange&
-    getScanRange() const;
-
     constexpr const ScanRange& scanRange() const;
-
-    /*! deprecated: use constexpr util::TenthOfDegree resolution() const instead */
-    [[deprecated("use constexpr util::TenthOfDegree resolution() const instead")]] constexpr util::TenthOfDegree
-    getResolution() const;
-
     constexpr util::TenthOfDegree resolution() const;
 
   private:
@@ -120,16 +111,6 @@ constexpr const ScanRange& Message::LaserScanSettings::scanRange() const
 constexpr util::TenthOfDegree Message::LaserScanSettings::resolution() const
 {
   return resolution_;
-};
-
-constexpr const ScanRange& Message::LaserScanSettings::getScanRange() const
-{
-  return this->scanRange();
-};
-
-constexpr util::TenthOfDegree Message::LaserScanSettings::getResolution() const
-{
-  return this->resolution();
 };
 
 constexpr Message::DeviceSettings::DeviceSettings(const bool diagnostics_enabled, const bool intensities_enabled)

--- a/standalone/include/psen_scan_v2_standalone/laserscan.h
+++ b/standalone/include/psen_scan_v2_standalone/laserscan.h
@@ -110,7 +110,7 @@ public:
   void intensities(const IntensityData& intensities);
 
   /*! deprecated: use const IOData& ioStates() const instead */
-  [[deprecated("use const IOData& getIOStates() const instead")]] const IOData& getIOStates() const;
+  [[deprecated("use const IOData& ioStates() const instead")]] const IOData& getIOStates() const;
   const IOData& ioStates() const;
 
   /*! deprecated: use void ioStates(const IOData& io_states) instead */

--- a/standalone/include/psen_scan_v2_standalone/laserscan.h
+++ b/standalone/include/psen_scan_v2_standalone/laserscan.h
@@ -109,8 +109,13 @@ public:
   setIntensities(const IntensityData& intensities);
   void intensities(const IntensityData& intensities);
 
-  const IOData& getIOStates() const;
-  void setIOStates(const IOData& io_states);
+  /*! deprecated: use const IOData& ioStates() const instead */
+  [[deprecated("use const IOData& getIOStates() const instead")]] const IOData& getIOStates() const;
+  const IOData& ioStates() const;
+
+  /*! deprecated: use void ioStates(const IOData& io_states) instead */
+  [[deprecated("use void ioStates(const IOData& io_states) instead")]] void setIOStates(const IOData& io_states);
+  void ioStates(const IOData& io_states);
 
 private:
   //! Measurement data of the laserscan (in Millimeters).

--- a/standalone/include/psen_scan_v2_standalone/laserscan.h
+++ b/standalone/include/psen_scan_v2_standalone/laserscan.h
@@ -59,19 +59,55 @@ public:
             const int64_t timestamp);
 
 public:
-  const util::TenthOfDegree& getScanResolution() const;
-  const util::TenthOfDegree& getMinScanAngle() const;
-  const util::TenthOfDegree& getMaxScanAngle() const;
-  uint32_t getScanCounter() const;
-  uint8_t getActiveZoneset() const;
-  int64_t getTimestamp() const;
+  /*! deprecated: use const util::TenthOfDegree& scanResolution() const instead */
+  [[deprecated("use const util::TenthOfDegree& scanResolution() const instead")]] const util::TenthOfDegree&
+  getScanResolution() const;
+  const util::TenthOfDegree& scanResolution() const;
 
-  const MeasurementData& getMeasurements() const;
-  MeasurementData& getMeasurements();
-  void setMeasurements(const MeasurementData& measurements);
+  /*! deprecated: use const util::TenthOfDegree& minScanAngle() const instead */
+  [[deprecated("use const util::TenthOfDegree& minScanAngle() const instead")]] const util::TenthOfDegree&
+  getMinScanAngle() const;
+  const util::TenthOfDegree& minScanAngle() const;
 
-  const IntensityData& getIntensities() const;
-  void setIntensities(const IntensityData& intensities);
+  /*! deprecated: use const util::TenthOfDegree& maxScanAngle() const instead */
+  [[deprecated("use const util::TenthOfDegree& maxScanAngle() const instead")]] const util::TenthOfDegree&
+  getMaxScanAngle() const;
+  const util::TenthOfDegree& maxScanAngle() const;
+
+  /*! deprecated: use uint32_t scanCounter() const instead */
+  [[deprecated("use uint32_t scanCounter() const instead")]] uint32_t getScanCounter() const;
+  uint32_t scanCounter() const;
+
+  /*! deprecated: use uint8_t activeZoneset() const instead */
+  [[deprecated("use uint8_t activeZoneset() const instead")]] uint8_t getActiveZoneset() const;
+  uint8_t activeZoneset() const;
+
+  /*! deprecated: use int64_t timestamp() const instead */
+  [[deprecated("use int64_t timestamp() const instead")]] int64_t getTimestamp() const;
+  int64_t timestamp() const;
+
+  /*! deprecated: use const MeasurementData& measurements() instead */
+  [[deprecated("use const MeasurementData& measurements() const instead")]] const MeasurementData&
+  getMeasurements() const;
+  const MeasurementData& measurements() const;
+
+  /*! deprecated: use MeasurementData& measurements() instead */
+  [[deprecated("use MeasurementData& measurements() instead")]] MeasurementData& getMeasurements();
+  MeasurementData& measurements();
+
+  /*! deprecated: use void measurements(const MeasurementData& measurements) instead */
+  [[deprecated("use void measurements(const MeasurementData& measurements) instead")]] void
+  setMeasurements(const MeasurementData& measurements);
+  void measurements(const MeasurementData& measurements);
+
+  /*! deprecated: use const IntensityData& intensities() instead */
+  [[deprecated("use const IntensityData& intensities() const instead")]] const IntensityData& getIntensities() const;
+  const IntensityData& intensities() const;
+
+  /*! deprecated: use void intensities(const IntensityData& intensities) instead */
+  [[deprecated("use void intensities(const IntensityData& intensities)) instead")]] void
+  setIntensities(const IntensityData& intensities);
+  void intensities(const IntensityData& intensities);
 
   const IOData& getIOStates() const;
   void setIOStates(const IOData& io_states);

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -100,12 +100,12 @@ public:
    */
   void reset();
 
-  /*! deprecated: use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round() instead */
-  [[deprecated("use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round() "
+  /*! deprecated: use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound() instead */
+  [[deprecated("use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound() "
                "instead")]] std::vector<data_conversion_layer::monitoring_frame::MessageStamped>
   getMsgs();
 
-  std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round();
+  std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound();
 
   bool isRoundComplete();
 
@@ -127,7 +127,7 @@ inline void ScanBuffer::reset()
   current_round_.clear();
 }
 
-inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::current_round()
+inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::currentRound()
 {
   return current_round_;
 }

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -99,7 +99,14 @@ public:
    * there is an expected brake in the receiving of MonitoringFrames.
    */
   void reset();
-  std::vector<data_conversion_layer::monitoring_frame::MessageStamped> getMsgs();
+
+  /*! deprecated: use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round() instead */
+  [[deprecated("use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round() "
+               "instead")]] std::vector<data_conversion_layer::monitoring_frame::MessageStamped>
+  getMsgs();
+
+  std::vector<data_conversion_layer::monitoring_frame::MessageStamped> current_round();
+
   bool isRoundComplete();
 
 private:
@@ -118,6 +125,11 @@ inline ScanBuffer::ScanBuffer(const uint32_t& num_expected_msgs) : num_expected_
 inline void ScanBuffer::reset()
 {
   current_round_.clear();
+}
+
+inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::current_round()
+{
+  return current_round_;
 }
 
 inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::getMsgs()

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -134,7 +134,7 @@ inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> Scan
 
 inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::getMsgs()
 {
-  return current_round_;
+  return this->currentRound();
 }
 
 inline bool ScanBuffer::isRoundComplete()

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scan_buffer.h
@@ -99,12 +99,6 @@ public:
    * there is an expected brake in the receiving of MonitoringFrames.
    */
   void reset();
-
-  /*! deprecated: use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound() instead */
-  [[deprecated("use std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound() "
-               "instead")]] std::vector<data_conversion_layer::monitoring_frame::MessageStamped>
-  getMsgs();
-
   std::vector<data_conversion_layer::monitoring_frame::MessageStamped> currentRound();
 
   bool isRoundComplete();
@@ -130,11 +124,6 @@ inline void ScanBuffer::reset()
 inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::currentRound()
 {
   return current_round_;
-}
-
-inline std::vector<data_conversion_layer::monitoring_frame::MessageStamped> ScanBuffer::getMsgs()
-{
-  return this->currentRound();
 }
 
 inline bool ScanBuffer::isRoundComplete()

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -253,7 +253,7 @@ inline void ScannerProtocolDef::informUserAboutTheScanData(
     scan_buffer_.add(stamped_msg);
     if (!config_.fragmentedScansEnabled() && scan_buffer_.isRoundComplete())
     {
-      sendMessageWithMeasurements(scan_buffer_.getMsgs());
+      sendMessageWithMeasurements(scan_buffer_.current_round());
     }
   }
   catch (const ScanRoundError& ex)

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -253,7 +253,7 @@ inline void ScannerProtocolDef::informUserAboutTheScanData(
     scan_buffer_.add(stamped_msg);
     if (!config_.fragmentedScansEnabled() && scan_buffer_.isRoundComplete())
     {
-      sendMessageWithMeasurements(scan_buffer_.current_round());
+      sendMessageWithMeasurements(scan_buffer_.currentRound());
     }
   }
   catch (const ScanRoundError& ex)

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -143,7 +143,7 @@ inline void ScannerProtocolDef::sendStartRequest(const T& event)
 
   if (!config_.hostIp())
   {
-    auto host_ip{ control_client_.getHostIp() };
+    auto host_ip{ control_client_.hostIp() };
     config_.hostIp(host_ip.to_ulong());
     PSENSCAN_INFO("StateMachine", "No host ip set! Using local ip: {}", host_ip.to_string());
   }

--- a/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
+++ b/standalone/include/psen_scan_v2_standalone/protocol_layer/scanner_state_machine_def.h
@@ -144,7 +144,7 @@ inline void ScannerProtocolDef::sendStartRequest(const T& event)
   if (!config_.hostIp())
   {
     auto host_ip{ control_client_.getHostIp() };
-    config_.setHostIp(host_ip.to_ulong());
+    config_.hostIp(host_ip.to_ulong());
     PSENSCAN_INFO("StateMachine", "No host ip set! Using local ip: {}", host_ip.to_string());
   }
   control_client_.write(

--- a/standalone/include/psen_scan_v2_standalone/scan_range.h
+++ b/standalone/include/psen_scan_v2_standalone/scan_range.h
@@ -41,8 +41,13 @@ public:
    */
   constexpr ScanRangeTemplated(const util::TenthOfDegree& start_angle, const util::TenthOfDegree& end_angle);
 
-  const util::TenthOfDegree& getStart() const;
-  const util::TenthOfDegree& getEnd() const;
+  /*! deprecated: use const util::TenthOfDegree& start() const instead */
+  [[deprecated("use const util::TenthOfDegree& start() const instead")]] const util::TenthOfDegree& getStart() const;
+  const util::TenthOfDegree& start() const;
+
+  /*! deprecated: use const util::TenthOfDegree& end() const instead */
+  [[deprecated("use const util::TenthOfDegree& end() const const instead")]] const util::TenthOfDegree& getEnd() const;
+  const util::TenthOfDegree& end() const;
 
 public:
   static constexpr ScanRangeTemplated<min_allowed_angle, max_allowed_angle> createInvalidScanRange();
@@ -83,6 +88,18 @@ template <int16_t min_angle, int16_t max_angle>
 constexpr ScanRangeTemplated<min_angle, max_angle> ScanRangeTemplated<min_angle, max_angle>::createInvalidScanRange()
 {
   return ScanRangeTemplated<min_angle, max_angle>();
+}
+
+template <int16_t min_angle, int16_t max_angle>
+const util::TenthOfDegree& ScanRangeTemplated<min_angle, max_angle>::start() const
+{
+  return start_angle_;
+}
+
+template <int16_t min_angle, int16_t max_angle>
+const util::TenthOfDegree& ScanRangeTemplated<min_angle, max_angle>::end() const
+{
+  return end_angle_;
 }
 
 template <int16_t min_angle, int16_t max_angle>

--- a/standalone/include/psen_scan_v2_standalone/scan_range.h
+++ b/standalone/include/psen_scan_v2_standalone/scan_range.h
@@ -105,13 +105,13 @@ const util::TenthOfDegree& ScanRangeTemplated<min_angle, max_angle>::end() const
 template <int16_t min_angle, int16_t max_angle>
 const util::TenthOfDegree& ScanRangeTemplated<min_angle, max_angle>::getStart() const
 {
-  return start_angle_;
+  return this->start();
 }
 
 template <int16_t min_angle, int16_t max_angle>
 const util::TenthOfDegree& ScanRangeTemplated<min_angle, max_angle>::getEnd() const
 {
-  return end_angle_;
+  return this->end();
 }
 
 using ScanRange = ScanRangeTemplated<1, 2749>;

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -158,7 +158,7 @@ inline void ScannerConfiguration::hostIp(const uint32_t& host_ip)
 
 inline void ScannerConfiguration::setHostIp(const uint32_t& host_ip)
 {
-  host_ip_ = host_ip;
+  this->hostIp(host_ip);
 }
 
 }  // namespace psen_scan_v2_standalone

--- a/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_configuration.h
@@ -53,7 +53,9 @@ public:
 
   bool fragmentedScansEnabled() const;
 
-  void setHostIp(const uint32_t& host_ip);
+  /*! deprecated: use void hostIp(const uint32_t& host_ip) instead */
+  [[deprecated("use void hostIp(const uint32_t& host_ip) instead")]] void setHostIp(const uint32_t& host_ip);
+  void hostIp(const uint32_t& host_ip);
 
 private:
   friend class ScannerConfigurationBuilder;
@@ -147,6 +149,11 @@ inline bool ScannerConfiguration::intensitiesEnabled() const
 inline bool ScannerConfiguration::fragmentedScansEnabled() const
 {
   return fragmented_scans_;
+}
+
+inline void ScannerConfiguration::hostIp(const uint32_t& host_ip)
+{
+  host_ip_ = host_ip;
 }
 
 inline void ScannerConfiguration::setHostIp(const uint32_t& host_ip)

--- a/standalone/include/psen_scan_v2_standalone/scanner_interface.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_interface.h
@@ -90,12 +90,12 @@ inline const IScanner::LaserScanCallback& IScanner::laserScanCallback() const
 
 inline const ScannerConfiguration& IScanner::getConfig() const
 {
-  return config_;
+  return this->config();
 }
 
 inline const IScanner::LaserScanCallback& IScanner::getLaserScanCallback() const
 {
-  return laser_scan_callback_;
+  return this->laserScanCallback();
 }
 
 }  // namespace psen_scan_v2_standalone

--- a/standalone/include/psen_scan_v2_standalone/scanner_interface.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_interface.h
@@ -54,8 +54,15 @@ public:
   virtual std::future<void> stop() = 0;
 
 protected:
-  const ScannerConfiguration& getConfig() const;
-  const LaserScanCallback& getLaserScanCallback() const;
+  /*! deprecated: use const ScannerConfiguration& config() const instead */
+  [[deprecated("use const ScannerConfiguration& config() const instead")]] const ScannerConfiguration&
+  getConfig() const;
+  const ScannerConfiguration& config() const;
+
+  /*! deprecated: use const LaserScanCallback& laserScanCallback() const instead */
+  [[deprecated("use const LaserScanCallback& laserScanCallback() const instead")]] const LaserScanCallback&
+  getLaserScanCallback() const;
+  const LaserScanCallback& laserScanCallback() const;
 
 private:
   const ScannerConfiguration config_;
@@ -69,6 +76,16 @@ inline IScanner::IScanner(const ScannerConfiguration& scanner_config, const Lase
   {
     throw std::invalid_argument("Laserscan-callback must not be null");
   }
+}
+
+inline const ScannerConfiguration& IScanner::config() const
+{
+  return config_;
+}
+
+inline const IScanner::LaserScanCallback& IScanner::laserScanCallback() const
+{
+  return laser_scan_callback_;
 }
 
 inline const ScannerConfiguration& IScanner::getConfig() const

--- a/standalone/main.cpp
+++ b/standalone/main.cpp
@@ -37,7 +37,7 @@ void laserScanCallback(const LaserScan& scan)
 {
   // Other data fields are listed on
   // https://docs.ros.org/en/melodic/api/psen_scan_v2/html/classpsen__scan__v2__standalone_1_1LaserScan.html
-  PSENSCAN_INFO_THROTTLE(1 /* sec */, "laserScanCallback()", "Ranges {}", util::formatRange(scan.getMeasurements()));
+  PSENSCAN_INFO_THROTTLE(1 /* sec */, "laserScanCallback()", "Ranges {}", util::formatRange(scan.measurements()));
 }
 
 int main(int argc, char** argv)

--- a/standalone/src/data_conversion_layer/diagnostics.cpp
+++ b/standalone/src/data_conversion_layer/diagnostics.cpp
@@ -36,7 +36,7 @@ std::ostream& operator<<(std::ostream& os, const Message& msg)
 
   if (isAmbiguous(msg.getDiagnosticCode()))
   {
-    os << fmt::format(" (Byte:{} Bit:{})", msg.getErrorLocation().getByte(), msg.getErrorLocation().getBit());
+    os << fmt::format(" (Byte:{} Bit:{})", msg.getErrorLocation().byte(), msg.getErrorLocation().bit());
   }
 
   return os;

--- a/standalone/src/data_conversion_layer/diagnostics.cpp
+++ b/standalone/src/data_conversion_layer/diagnostics.cpp
@@ -31,12 +31,12 @@ namespace diagnostic
 std::ostream& operator<<(std::ostream& os, const Message& msg)
 {
   os << fmt::format("Device: {} - {}",
-                    configuration::SCANNER_ID_TO_STRING.at(msg.getScannerId()),
-                    ERROR_CODE_TO_STRING.at(msg.getDiagnosticCode()));
+                    configuration::SCANNER_ID_TO_STRING.at(msg.scannerId()),
+                    ERROR_CODE_TO_STRING.at(msg.diagnosticCode()));
 
-  if (isAmbiguous(msg.getDiagnosticCode()))
+  if (isAmbiguous(msg.diagnosticCode()))
   {
-    os << fmt::format(" (Byte:{} Bit:{})", msg.getErrorLocation().byte(), msg.getErrorLocation().bit());
+    os << fmt::format(" (Byte:{} Bit:{})", msg.errorLocation().byte(), msg.errorLocation().bit());
   }
 
   return os;

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -98,8 +98,8 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
   raw_processing::write(os, speed_encoder_enabled);
   raw_processing::write(os, diagnostics_enabled);
 
-  const auto start = msg.master_.getScanRange().getStart().value();
-  auto end = msg.master_.getScanRange().getEnd().value();
+  const auto start = msg.master_.getScanRange().start().value();
+  auto end = msg.master_.getScanRange().end().value();
   const auto resolution = msg.master_.getResolution().value();
 
   /* In order to get all the data points we want, the scanner needs a value
@@ -120,8 +120,8 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
 
   for (const auto& slave : msg.slaves_)
   {
-    raw_processing::write(os, slave.getScanRange().getStart().value());
-    raw_processing::write(os, slave.getScanRange().getEnd().value());
+    raw_processing::write(os, slave.getScanRange().start().value());
+    raw_processing::write(os, slave.getScanRange().end().value());
     raw_processing::write(os, slave.getResolution().value());
   }
 

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -98,9 +98,9 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
   raw_processing::write(os, speed_encoder_enabled);
   raw_processing::write(os, diagnostics_enabled);
 
-  const auto start = msg.master_.getScanRange().start().value();
-  auto end = msg.master_.getScanRange().end().value();
-  const auto resolution = msg.master_.getResolution().value();
+  const auto start = msg.master_.scanRange().start().value();
+  auto end = msg.master_.scanRange().end().value();
+  const auto resolution = msg.master_.resolution().value();
 
   /* In order to get all the data points we want, the scanner needs a value
      that is strictly greater than the end point */
@@ -120,9 +120,9 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
 
   for (const auto& slave : msg.slaves_)
   {
-    raw_processing::write(os, slave.getScanRange().start().value());
-    raw_processing::write(os, slave.getScanRange().end().value());
-    raw_processing::write(os, slave.getResolution().value());
+    raw_processing::write(os, slave.scanRange().start().value());
+    raw_processing::write(os, slave.scanRange().end().value());
+    raw_processing::write(os, slave.resolution().value());
   }
 
   const std::string raw_data_as_str{ os.str() };

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -172,10 +172,20 @@ void LaserScan::intensities(const IntensityData& intensities)
 
 void LaserScan::setIOStates(const IOData& io_states)
 {
-  io_states_ = io_states;
+  ioStates(io_states);
 }
 
 const LaserScan::IOData& LaserScan::getIOStates() const
+{
+  return ioStates();
+}
+
+void LaserScan::ioStates(const IOData& io_states)
+{
+  io_states_ = io_states;
+}
+
+const LaserScan::IOData& LaserScan::ioStates() const
 {
   return io_states_;
 }
@@ -192,7 +202,7 @@ std::ostream& operator<<(std::ostream& os, const LaserScan& scan)
                     scan.activeZoneset(),
                     util::formatRange(scan.measurements()),
                     util::formatRange(scan.intensities()),
-                    util::formatRange(scan.getIOStates()));
+                    util::formatRange(scan.ioStates()));
   return os;
 }
 

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -42,25 +42,40 @@ LaserScan::LaserScan(const util::TenthOfDegree& resolution,
   , active_zoneset_(active_zoneset)
   , timestamp_(timestamp)
 {
-  if (getScanResolution() == util::TenthOfDegree(0))
+  if (scanResolution() == util::TenthOfDegree(0))
   {
     throw std::invalid_argument("Resolution must not be 0");
   }
 
-  if (getScanResolution() > MAX_X_AXIS_ROTATION)
+  if (scanResolution() > MAX_X_AXIS_ROTATION)
   {
     throw std::invalid_argument("Resolution out of possible angle range");
   }
 
-  if (getMinScanAngle() > getMaxScanAngle())
+  if (minScanAngle() > maxScanAngle())
   {
     throw std::invalid_argument("Attention: Start angle has to be smaller or equal to the end angle!");
   }
 }
 
+const util::TenthOfDegree& LaserScan::scanResolution() const
+{
+  return resolution_;
+}
+
 const util::TenthOfDegree& LaserScan::getScanResolution() const
 {
   return resolution_;
+}
+
+const util::TenthOfDegree& LaserScan::minScanAngle() const
+{
+  return min_scan_angle_;
+}
+
+const util::TenthOfDegree& LaserScan::maxScanAngle() const
+{
+  return max_scan_angle_;
 }
 
 const util::TenthOfDegree& LaserScan::getMinScanAngle() const
@@ -78,14 +93,34 @@ const LaserScan::MeasurementData& LaserScan::getMeasurements() const
   return measurements_;
 }
 
+const LaserScan::MeasurementData& LaserScan::measurements() const
+{
+  return measurements_;
+}
+
+uint32_t LaserScan::scanCounter() const
+{
+  return scan_counter_;
+}
+
 uint32_t LaserScan::getScanCounter() const
 {
   return scan_counter_;
 }
 
+uint8_t LaserScan::activeZoneset() const
+{
+  return active_zoneset_;
+}
+
 uint8_t LaserScan::getActiveZoneset() const
 {
   return active_zoneset_;
+}
+
+int64_t LaserScan::timestamp() const
+{
+  return timestamp_;
 }
 
 int64_t LaserScan::getTimestamp() const
@@ -98,7 +133,17 @@ void LaserScan::setMeasurements(const MeasurementData& measurements)
   measurements_ = measurements;
 }
 
+void LaserScan::measurements(const MeasurementData& measurements)
+{
+  measurements_ = measurements;
+}
+
 LaserScan::MeasurementData& LaserScan::getMeasurements()
+{
+  return measurements_;
+}
+
+LaserScan::MeasurementData& LaserScan::measurements()
 {
   return measurements_;
 }
@@ -106,6 +151,16 @@ LaserScan::MeasurementData& LaserScan::getMeasurements()
 const LaserScan::IntensityData& LaserScan::getIntensities() const
 {
   return intensities_;
+}
+
+const LaserScan::IntensityData& LaserScan::intensities() const
+{
+  return intensities_;
+}
+
+void LaserScan::intensities(const IntensityData& intensities)
+{
+  intensities_ = intensities;
 }
 
 void LaserScan::setIntensities(const IntensityData& intensities)
@@ -127,14 +182,14 @@ std::ostream& operator<<(std::ostream& os, const LaserScan& scan)
 {
   os << fmt::format("LaserScan(timestamp = {} nsec, scanCounter = {}, minScanAngle = {} deg, maxScanAngle = {} deg, "
                     "resolution = {} deg, active_zoneset = {}, measurements = {}, intensities = {}, io_states = {})",
-                    scan.getTimestamp(),
-                    scan.getScanCounter(),
-                    scan.getMinScanAngle().value() / 10.,
-                    scan.getMaxScanAngle().value() / 10.,
-                    scan.getScanResolution().value() / 10.,
-                    scan.getActiveZoneset(),
-                    util::formatRange(scan.getMeasurements()),
-                    util::formatRange(scan.getIntensities()),
+                    scan.timestamp(),
+                    scan.scanCounter(),
+                    scan.minScanAngle().value() / 10.,
+                    scan.maxScanAngle().value() / 10.,
+                    scan.scanResolution().value() / 10.,
+                    scan.activeZoneset(),
+                    util::formatRange(scan.measurements()),
+                    util::formatRange(scan.intensities()),
                     util::formatRange(scan.getIOStates()));
   return os;
 }

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -170,6 +170,7 @@ void LaserScan::intensities(const IntensityData& intensities)
   intensities_ = intensities;
 }
 
+// LCOV_EXCL_START
 void LaserScan::setIOStates(const IOData& io_states)
 {
   ioStates(io_states);
@@ -179,6 +180,7 @@ const LaserScan::IOData& LaserScan::getIOStates() const
 {
   return ioStates();
 }
+// LCOV_EXCL_STOP
 
 void LaserScan::ioStates(const IOData& io_states)
 {

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -66,57 +66,57 @@ const util::TenthOfDegree& LaserScan::scanResolution() const
 // LCOV_EXCL_START
 const util::TenthOfDegree& LaserScan::getScanResolution() const
 {
-  return resolution_;
+  return this->scanResolution();
 }
 
 const util::TenthOfDegree& LaserScan::getMinScanAngle() const
 {
-  return min_scan_angle_;
+  return this->minScanAngle();
 }
 
 const util::TenthOfDegree& LaserScan::getMaxScanAngle() const
 {
-  return max_scan_angle_;
+  return this->maxScanAngle();
 }
 
 const LaserScan::MeasurementData& LaserScan::getMeasurements() const
 {
-  return measurements_;
+  return this->measurements();
 }
 
 uint32_t LaserScan::getScanCounter() const
 {
-  return scan_counter_;
+  return this->scanCounter();
 }
 
 int64_t LaserScan::getTimestamp() const
 {
-  return timestamp_;
+  return this->timestamp();
 }
 
 uint8_t LaserScan::getActiveZoneset() const
 {
-  return active_zoneset_;
+  return this->activeZoneset();
 }
 
 void LaserScan::setMeasurements(const MeasurementData& measurements)
 {
-  measurements_ = measurements;
+  this->measurements(measurements);
 }
 
 LaserScan::MeasurementData& LaserScan::getMeasurements()
 {
-  return measurements_;
+  return this->measurements();
 }
 
 const LaserScan::IntensityData& LaserScan::getIntensities() const
 {
-  return intensities_;
+  return this->intensities();
 }
 
 void LaserScan::setIntensities(const IntensityData& intensities)
 {
-  intensities_ = intensities;
+  this->intensities(intensities);
 }
 // LCOV_EXCL_STOP
 

--- a/standalone/src/laserscan.cpp
+++ b/standalone/src/laserscan.cpp
@@ -63,19 +63,10 @@ const util::TenthOfDegree& LaserScan::scanResolution() const
   return resolution_;
 }
 
+// LCOV_EXCL_START
 const util::TenthOfDegree& LaserScan::getScanResolution() const
 {
   return resolution_;
-}
-
-const util::TenthOfDegree& LaserScan::minScanAngle() const
-{
-  return min_scan_angle_;
-}
-
-const util::TenthOfDegree& LaserScan::maxScanAngle() const
-{
-  return max_scan_angle_;
 }
 
 const util::TenthOfDegree& LaserScan::getMinScanAngle() const
@@ -93,6 +84,52 @@ const LaserScan::MeasurementData& LaserScan::getMeasurements() const
   return measurements_;
 }
 
+uint32_t LaserScan::getScanCounter() const
+{
+  return scan_counter_;
+}
+
+int64_t LaserScan::getTimestamp() const
+{
+  return timestamp_;
+}
+
+uint8_t LaserScan::getActiveZoneset() const
+{
+  return active_zoneset_;
+}
+
+void LaserScan::setMeasurements(const MeasurementData& measurements)
+{
+  measurements_ = measurements;
+}
+
+LaserScan::MeasurementData& LaserScan::getMeasurements()
+{
+  return measurements_;
+}
+
+const LaserScan::IntensityData& LaserScan::getIntensities() const
+{
+  return intensities_;
+}
+
+void LaserScan::setIntensities(const IntensityData& intensities)
+{
+  intensities_ = intensities;
+}
+// LCOV_EXCL_STOP
+
+const util::TenthOfDegree& LaserScan::minScanAngle() const
+{
+  return min_scan_angle_;
+}
+
+const util::TenthOfDegree& LaserScan::maxScanAngle() const
+{
+  return max_scan_angle_;
+}
+
 const LaserScan::MeasurementData& LaserScan::measurements() const
 {
   return measurements_;
@@ -103,17 +140,7 @@ uint32_t LaserScan::scanCounter() const
   return scan_counter_;
 }
 
-uint32_t LaserScan::getScanCounter() const
-{
-  return scan_counter_;
-}
-
 uint8_t LaserScan::activeZoneset() const
-{
-  return active_zoneset_;
-}
-
-uint8_t LaserScan::getActiveZoneset() const
 {
   return active_zoneset_;
 }
@@ -123,34 +150,14 @@ int64_t LaserScan::timestamp() const
   return timestamp_;
 }
 
-int64_t LaserScan::getTimestamp() const
-{
-  return timestamp_;
-}
-
-void LaserScan::setMeasurements(const MeasurementData& measurements)
-{
-  measurements_ = measurements;
-}
-
 void LaserScan::measurements(const MeasurementData& measurements)
 {
   measurements_ = measurements;
 }
 
-LaserScan::MeasurementData& LaserScan::getMeasurements()
-{
-  return measurements_;
-}
-
 LaserScan::MeasurementData& LaserScan::measurements()
 {
   return measurements_;
-}
-
-const LaserScan::IntensityData& LaserScan::getIntensities() const
-{
-  return intensities_;
 }
 
 const LaserScan::IntensityData& LaserScan::intensities() const
@@ -159,11 +166,6 @@ const LaserScan::IntensityData& LaserScan::intensities() const
 }
 
 void LaserScan::intensities(const IntensityData& intensities)
-{
-  intensities_ = intensities;
-}
-
-void LaserScan::setIntensities(const IntensityData& intensities)
 {
   intensities_ = intensities;
 }

--- a/standalone/src/scanner_v2.cpp
+++ b/standalone/src/scanner_v2.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<util::Watchdog> WatchdogFactory::create(const util::Watchdog::Ti
 
 ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback)
   : IScanner(scanner_config, laser_scan_callback)
-  , sm_(new ScannerStateMachine(IScanner::getConfig(),
+  , sm_(new ScannerStateMachine(IScanner::config(),
                                 // LCOV_EXCL_START
                                 // The following includes calls to std::bind which are not marked correctly
                                 // by some gcc versions, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96006
@@ -52,7 +52,7 @@ ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScan
                                 BIND_EVENT(MonitoringFrameReceivedError),
                                 std::bind(&ScannerV2::scannerStartedCallback, this),
                                 std::bind(&ScannerV2::scannerStoppedCallback, this),
-                                IScanner::getLaserScanCallback(),
+                                IScanner::laserScanCallback(),
                                 BIND_EVENT(scanner_events::StartTimeout),
                                 BIND_EVENT(scanner_events::MonitoringFrameTimeout)))
 // LCOV_EXCL_STOP

--- a/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
@@ -78,8 +78,8 @@ static std::vector<double> generateIntensities(const unsigned int& num_elements,
 }
 
 static data_conversion_layer::monitoring_frame::MessageBuilder
-createMonitoringFrameMsgBuilderWithoutDiagnostics(const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.getStart(),
-                                                  const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.getEnd())
+createMonitoringFrameMsgBuilderWithoutDiagnostics(const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.start(),
+                                                  const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.end())
 {
   const auto resolution{ util::TenthOfDegree(10) };
   data_conversion_layer::monitoring_frame::MessageBuilder msg_builder;
@@ -148,9 +148,9 @@ createMonitoringFrameMsgsForScanRound(const uint32_t scan_counter, const std::si
   for (std::size_t i = 0; i < num_elements; ++i)
   {
     const util::TenthOfDegree start_angle =
-        (DEFAULT_SCAN_RANGE.getEnd() / static_cast<int>(num_elements)) * static_cast<int>(i);
+        (DEFAULT_SCAN_RANGE.end() / static_cast<int>(num_elements)) * static_cast<int>(i);
     const util::TenthOfDegree end_angle =
-        (DEFAULT_SCAN_RANGE.getEnd() / static_cast<int>(num_elements)) * static_cast<int>(i + 1);
+        (DEFAULT_SCAN_RANGE.end() / static_cast<int>(num_elements)) * static_cast<int>(i + 1);
     msgs.push_back(createMonitoringFrameMsgBuilder(start_angle, end_angle).scanCounter(scan_counter));
   }
   return msgs;

--- a/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/integrationtest_helper.h
@@ -104,8 +104,8 @@ createMonitoringFrameMsgBuilderWithoutDiagnostics(const util::TenthOfDegree star
 }
 
 static data_conversion_layer::monitoring_frame::MessageBuilder
-createMonitoringFrameMsgBuilder(const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.getStart(),
-                                const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.getEnd())
+createMonitoringFrameMsgBuilder(const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.start(),
+                                const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.end())
 {
   return createMonitoringFrameMsgBuilderWithoutDiagnostics(start_angle, end_angle)
       .diagnosticMessages({ { configuration::ScannerId::master,
@@ -114,8 +114,8 @@ createMonitoringFrameMsgBuilder(const util::TenthOfDegree start_angle = DEFAULT_
 
 static data_conversion_layer::monitoring_frame::Message
 createMonitoringFrameMsg(const uint32_t scan_counter = DEFAULT_SCAN_COUNTER,
-                         const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.getStart(),
-                         const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.getEnd())
+                         const util::TenthOfDegree start_angle = DEFAULT_SCAN_RANGE.start(),
+                         const util::TenthOfDegree end_angle = DEFAULT_SCAN_RANGE.end())
 {
   return createMonitoringFrameMsgBuilder(start_angle, end_angle).scanCounter(scan_counter);
 }
@@ -181,14 +181,14 @@ void PrintTo(const LaserScan& scan, std::ostream* os)
 {
   *os << fmt::format("LaserScan(timestamp = {} nsec, scanCounter = {}, minScanAngle = {} deg, maxScanAngle = {} deg, "
                      "resolution = {} deg, active_zoneset = {}, measurements = {}, intensities = {}, io_states = ...)",
-                     scan.getTimestamp(),
-                     scan.getScanCounter(),
-                     scan.getMinScanAngle().value() / 10.,
-                     scan.getMaxScanAngle().value() / 10.,
-                     scan.getScanResolution().value() / 10.,
-                     scan.getActiveZoneset(),
-                     util::formatRange(scan.getMeasurements()),
-                     util::formatRange(scan.getIntensities()));
+                     scan.timestamp(),
+                     scan.scanCounter(),
+                     scan.minScanAngle().value() / 10.,
+                     scan.maxScanAngle().value() / 10.,
+                     scan.scanResolution().value() / 10.,
+                     scan.activeZoneset(),
+                     util::formatRange(scan.measurements()),
+                     util::formatRange(scan.intensities()));
 }
 }  // namespace psen_scan_v2_standalone
 

--- a/standalone/test/include/psen_scan_v2_standalone/util/matchers_and_actions.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/matchers_and_actions.h
@@ -89,7 +89,7 @@ MATCHER_P(ScanDataEqual, scan, "")
          arg.minScanAngle() == scan.minScanAngle() && arg.maxScanAngle() == scan.maxScanAngle() &&
          Matches(PointwiseDoubleEq(scan.measurements()))(arg.measurements()) &&
          Matches(PointwiseDoubleEq(scan.intensities()))(arg.intensities()) &&
-         ExplainMatchResult(PointwiseIOStateUnorderedEq(scan.getIOStates()), arg.getIOStates(), result_listener);
+         ExplainMatchResult(PointwiseIOStateUnorderedEq(scan.ioStates()), arg.ioStates(), result_listener);
 }
 
 MATCHER_P2(TimestampInExpectedTimeframe, reference_scan, reference_timestamp, "")

--- a/standalone/test/include/psen_scan_v2_standalone/util/matchers_and_actions.h
+++ b/standalone/test/include/psen_scan_v2_standalone/util/matchers_and_actions.h
@@ -85,10 +85,10 @@ MATCHER_P(PointwiseIOStateUnorderedEq, vec, "")
 
 MATCHER_P(ScanDataEqual, scan, "")
 {
-  return arg.getScanCounter() == scan.getScanCounter() && arg.getScanResolution() == scan.getScanResolution() &&
-         arg.getMinScanAngle() == scan.getMinScanAngle() && arg.getMaxScanAngle() == scan.getMaxScanAngle() &&
-         Matches(PointwiseDoubleEq(scan.getMeasurements()))(arg.getMeasurements()) &&
-         Matches(PointwiseDoubleEq(scan.getIntensities()))(arg.getIntensities()) &&
+  return arg.scanCounter() == scan.scanCounter() && arg.scanResolution() == scan.scanResolution() &&
+         arg.minScanAngle() == scan.minScanAngle() && arg.maxScanAngle() == scan.maxScanAngle() &&
+         Matches(PointwiseDoubleEq(scan.measurements()))(arg.measurements()) &&
+         Matches(PointwiseDoubleEq(scan.intensities()))(arg.intensities()) &&
          ExplainMatchResult(PointwiseIOStateUnorderedEq(scan.getIOStates()), arg.getIOStates(), result_listener);
 }
 
@@ -96,8 +96,7 @@ MATCHER_P2(TimestampInExpectedTimeframe, reference_scan, reference_timestamp, ""
 {
   const int64_t elapsed_time{ util::getCurrentTime() - reference_timestamp };
   *result_listener << "where the elapsed time is " << elapsed_time << " nsec";
-  return arg.getTimestamp() > reference_scan.getTimestamp() &&
-         arg.getTimestamp() < (reference_scan.getTimestamp() + elapsed_time);
+  return arg.timestamp() > reference_scan.timestamp() && arg.timestamp() < (reference_scan.timestamp() + elapsed_time);
 }
 
 MATCHER_P(IOPinDataEq, ref_pin, "")

--- a/standalone/test/integration_tests/communication_layer/integrationtest_udp_client.cpp
+++ b/standalone/test/integration_tests/communication_layer/integrationtest_udp_client.cpp
@@ -128,7 +128,7 @@ data_conversion_layer::RawData createRawData(std::string dataString)
 
 TEST_F(UdpClientTests, testGetHostIp)
 {
-  EXPECT_EQ(HOST_IP_ADDRESS, udp_client_->getHostIp().to_string());
+  EXPECT_EQ(HOST_IP_ADDRESS, udp_client_->hostIp().to_string());
 }
 
 TEST_F(UdpClientTests, testAsyncReadOperation)

--- a/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
+++ b/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
@@ -116,7 +116,7 @@ constexpr size_t calculateIndexInRawDiagnosticData(const configuration::ScannerI
                                                    const diagnostic::ErrorLocation& location)
 {
   return diagnostic::RAW_CHUNK_UNUSED_OFFSET_IN_BYTES +
-         (static_cast<uint8_t>(id) * diagnostic::RAW_CHUNK_LENGTH_FOR_ONE_DEVICE_IN_BYTES) + location.getByte();
+         (static_cast<uint8_t>(id) * diagnostic::RAW_CHUNK_LENGTH_FOR_ONE_DEVICE_IN_BYTES) + location.byte();
 }
 
 namespace diagnostic
@@ -128,7 +128,7 @@ RawChunk serialize(const std::vector<data_conversion_layer::monitoring_frame::di
   for (const auto& elem : messages)
   {
     raw_diagnostic_data.at(calculateIndexInRawDiagnosticData(elem.getScannerId(), elem.getErrorLocation())) +=
-        (1 << elem.getErrorLocation().getBit());
+        (1 << elem.getErrorLocation().bit());
   }
   return raw_diagnostic_data;
 }

--- a/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
+++ b/standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
@@ -127,8 +127,8 @@ RawChunk serialize(const std::vector<data_conversion_layer::monitoring_frame::di
 
   for (const auto& elem : messages)
   {
-    raw_diagnostic_data.at(calculateIndexInRawDiagnosticData(elem.getScannerId(), elem.getErrorLocation())) +=
-        (1 << elem.getErrorLocation().bit());
+    raw_diagnostic_data.at(calculateIndexInRawDiagnosticData(elem.scannerId(), elem.errorLocation())) +=
+        (1 << elem.errorLocation().bit());
   }
   return raw_diagnostic_data;
 }

--- a/standalone/test/unit_tests/api/unittest_laserscan.cpp
+++ b/standalone/test/unit_tests/api/unittest_laserscan.cpp
@@ -109,7 +109,7 @@ TEST(LaserScanTest, testGetScanResolution)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_RESOLUTION, laser_scan->getScanResolution());
+  EXPECT_EQ(DEFAULT_RESOLUTION, laser_scan->scanResolution());
 }
 
 TEST(LaserScanTest, testGetMinScanAngle)
@@ -117,7 +117,7 @@ TEST(LaserScanTest, testGetMinScanAngle)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_START_ANGLE, laser_scan->getMinScanAngle());
+  EXPECT_EQ(DEFAULT_START_ANGLE, laser_scan->minScanAngle());
 }
 
 TEST(LaserScanTest, testGetMaxScanAngle)
@@ -125,7 +125,7 @@ TEST(LaserScanTest, testGetMaxScanAngle)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_END_ANGLE, laser_scan->getMaxScanAngle());
+  EXPECT_EQ(DEFAULT_END_ANGLE, laser_scan->maxScanAngle());
 }
 
 TEST(LaserScanTest, testMinEqualsMax)
@@ -140,7 +140,7 @@ TEST(LaserScanTest, testGetScanCounter)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_SCAN_COUNTER, laser_scan->getScanCounter());
+  EXPECT_EQ(DEFAULT_SCAN_COUNTER, laser_scan->scanCounter());
 }
 
 TEST(LaserScanTest, testGetTimestamp)
@@ -148,7 +148,7 @@ TEST(LaserScanTest, testGetTimestamp)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_TIMESTAMP, laser_scan->getTimestamp());
+  EXPECT_EQ(DEFAULT_TIMESTAMP, laser_scan->timestamp());
 }
 
 TEST(LaserScanTest, testGetActiveZoneset)
@@ -156,7 +156,7 @@ TEST(LaserScanTest, testGetActiveZoneset)
   LaserScanBuilder laser_scan_builder;
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
-  EXPECT_EQ(DEFAULT_ACTIVE_ZONESET, laser_scan->getActiveZoneset());
+  EXPECT_EQ(DEFAULT_ACTIVE_ZONESET, laser_scan->activeZoneset());
 }
 
 TEST(LaserScanTest, testSetAndGetIOStates)
@@ -176,7 +176,7 @@ TEST(LaserScanTest, testPrintMessageSuccess)
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
 
-  laser_scan->setMeasurements({ 45.0, 44.0, 43.0, 42.0 });
+  laser_scan->measurements({ 45.0, 44.0, 43.0, 42.0 });
   laser_scan->setIOStates({ { { PinState(3, "io_pin_data", true) }, {} } });
 
 // For compatibility with different ubuntu versions (resp. fmt), we need to take account of changes in

--- a/standalone/test/unit_tests/api/unittest_laserscan.cpp
+++ b/standalone/test/unit_tests/api/unittest_laserscan.cpp
@@ -165,9 +165,9 @@ TEST(LaserScanTest, testSetAndGetIOStates)
   std::unique_ptr<LaserScan> laser_scan;
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
 
-  laser_scan->setIOStates({ DEFAULT_IO_STATE });
-  EXPECT_EQ(laser_scan->getIOStates()[0].logicalInput(), DEFAULT_IO_STATE.logicalInput());
-  EXPECT_EQ(laser_scan->getIOStates()[0].output(), DEFAULT_IO_STATE.output());
+  laser_scan->ioStates({ DEFAULT_IO_STATE });
+  EXPECT_EQ(laser_scan->ioStates()[0].logicalInput(), DEFAULT_IO_STATE.logicalInput());
+  EXPECT_EQ(laser_scan->ioStates()[0].output(), DEFAULT_IO_STATE.output());
 }
 
 TEST(LaserScanTest, testPrintMessageSuccess)
@@ -177,7 +177,7 @@ TEST(LaserScanTest, testPrintMessageSuccess)
   ASSERT_NO_THROW(laser_scan.reset(new LaserScan(laser_scan_builder.build())););
 
   laser_scan->measurements({ 45.0, 44.0, 43.0, 42.0 });
-  laser_scan->setIOStates({ { { PinState(3, "io_pin_data", true) }, {} } });
+  laser_scan->ioStates({ { { PinState(3, "io_pin_data", true) }, {} } });
 
 // For compatibility with different ubuntu versions (resp. fmt), we need to take account of changes in
 // the default formatting of floating point numbers

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -265,7 +265,7 @@ TEST_F(ScannerConfigurationTest, shouldReturnSetHostIp)
   ScannerConfiguration sc{ createValidConfig() };
 
   const uint32_t host_ip{ util::convertIP(VALID_IP_OTHER) };
-  sc.setHostIp(host_ip);
+  sc.hostIp(host_ip);
 
   EXPECT_EQ(host_ip, sc.hostIp());
 }

--- a/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
+++ b/standalone/test/unit_tests/configuration/unittest_scanner_configuration.cpp
@@ -250,14 +250,14 @@ TEST_F(ScannerConfigurationTest, shouldReturnCorrectStartAngleAfterConstruction)
 {
   const ScannerConfiguration sc{ createValidConfig() };
 
-  EXPECT_EQ(SCAN_RANGE.getStart(), sc.scanRange().getStart());
+  EXPECT_EQ(SCAN_RANGE.start(), sc.scanRange().start());
 }
 
 TEST_F(ScannerConfigurationTest, shouldReturnCorrectEndAngleAfterConstruction)
 {
   const ScannerConfiguration sc{ createValidConfig() };
 
-  EXPECT_EQ(SCAN_RANGE.getEnd(), sc.scanRange().getEnd());
+  EXPECT_EQ(SCAN_RANGE.end(), sc.scanRange().end());
 }
 
 TEST_F(ScannerConfigurationTest, shouldReturnSetHostIp)

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_laserscan_conversions.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_laserscan_conversions.cpp
@@ -144,7 +144,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectScanResolutionAfterC
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  EXPECT_EQ(stamped_msg.msg_.resolution(), scan_ptr->getScanResolution()) << "Resolution incorrect in LaserScan";
+  EXPECT_EQ(stamped_msg.msg_.resolution(), scan_ptr->scanResolution()) << "Resolution incorrect in LaserScan";
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectMinMaxScanAngleAfterConversion)
@@ -159,8 +159,8 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectMinMaxScanAngleAfter
     stamped_msg.msg_.resolution() * (static_cast<int>(stamped_msg.msg_.measurements().size()) - 1)
   };
 
-  EXPECT_EQ(stamped_msg.msg_.fromTheta(), scan_ptr->getMinScanAngle()) << "Min scan-angle incorrect in LaserScan";
-  EXPECT_EQ(expected_max_scan_angle, scan_ptr->getMaxScanAngle()) << "Max scan-angle incorrect in LaserScan";
+  EXPECT_EQ(stamped_msg.msg_.fromTheta(), scan_ptr->minScanAngle()) << "Min scan-angle incorrect in LaserScan";
+  EXPECT_EQ(expected_max_scan_angle, scan_ptr->maxScanAngle()) << "Max scan-angle incorrect in LaserScan";
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectMeasurementsAfterConversion)
@@ -171,7 +171,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectMeasurementsAfterCon
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  EXPECT_THAT(scan_ptr->getMeasurements(), PointwiseDoubleEq(stamped_msg.msg_.measurements()));
+  EXPECT_THAT(scan_ptr->measurements(), PointwiseDoubleEq(stamped_msg.msg_.measurements()));
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectIntensitiesAfterConversion)
@@ -182,7 +182,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectIntensitiesAfterConv
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  EXPECT_THAT(scan_ptr->getIntensities(), PointwiseDoubleEq(stamped_msg.msg_.intensities()));
+  EXPECT_THAT(scan_ptr->intensities(), PointwiseDoubleEq(stamped_msg.msg_.intensities()));
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectScanCounterAfterConversion)
@@ -193,7 +193,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectScanCounterAfterConv
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  EXPECT_EQ(stamped_msg.msg_.scanCounter(), scan_ptr->getScanCounter());
+  EXPECT_EQ(stamped_msg.msg_.scanCounter(), scan_ptr->scanCounter());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectTimestampAfterConversion)
@@ -204,7 +204,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectTimestampAfterConver
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->getTimestamp());
+  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->timestamp());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectIOStateAfterConversion)
@@ -260,8 +260,8 @@ TEST(LaserScanConversionsTest, laserScanShouldContainAllScanInformationWhenBuild
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
 
-  EXPECT_EQ(stamped_msgs.size() * stamped_msgs[0].msg_.measurements().size(), scan_ptr->getMeasurements().size());
-  EXPECT_EQ(stamped_msgs.size() * stamped_msgs[0].msg_.intensities().size(), scan_ptr->getIntensities().size());
+  EXPECT_EQ(stamped_msgs.size() * stamped_msgs[0].msg_.measurements().size(), scan_ptr->measurements().size());
+  EXPECT_EQ(stamped_msgs.size() * stamped_msgs[0].msg_.intensities().size(), scan_ptr->intensities().size());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainCorrectTimestampWhenBuildingWithMulitpleFrames)
@@ -270,7 +270,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectTimestampWhenBuildin
   std::unique_ptr<LaserScan> scan_ptr;
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
-  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->getTimestamp());
+  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->timestamp());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainMeasurementsOrderedByThetaAngle)
@@ -286,8 +286,8 @@ TEST(LaserScanConversionsTest, laserScanShouldContainMeasurementsOrderedByThetaA
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
 
-  EXPECT_EQ(first_measurement, scan_ptr->getMeasurements().front());
-  EXPECT_EQ(last_measurement, scan_ptr->getMeasurements().back());
+  EXPECT_EQ(first_measurement, scan_ptr->measurements().front());
+  EXPECT_EQ(last_measurement, scan_ptr->measurements().back());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainMinimalTimestamp)
@@ -298,7 +298,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainMinimalTimestamp)
   std::unique_ptr<LaserScan> scan_ptr;
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
-  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->getTimestamp());
+  EXPECT_EQ(EXPECTED_TIMESTAMP_AFTER_CONVERSION, scan_ptr->timestamp());
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainAllIOStates)
@@ -342,7 +342,7 @@ TEST(LaserScanConversionsTest, laserScanShouldContainActiveZonesetOfLastMsg)
   std::unique_ptr<LaserScan> scan_ptr;
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
-  EXPECT_EQ(4, scan_ptr->getActiveZoneset());
+  EXPECT_EQ(4, scan_ptr->activeZoneset());
 }
 
 TEST(LaserScanConversionTest, conversionShouldIgnoreEmptyFramesWhenCheckingIfFromThetasFitTogether)
@@ -379,7 +379,7 @@ TEST(LaserScanConversionsTest, conversionShouldIgnoreEmptyFramesForTimestampsCom
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
 
-  EXPECT_EQ(expected_stamp, scan_ptr->getTimestamp());
+  EXPECT_EQ(expected_stamp, scan_ptr->timestamp());
 }
 
 }  // namespace psen_scan_v2_standalone_test

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_laserscan_conversions.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_laserscan_conversions.cpp
@@ -215,8 +215,8 @@ TEST(LaserScanConversionsTest, laserScanShouldContainCorrectIOStateAfterConversi
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan({ stamped_msg }) }););
 
-  ASSERT_EQ(scan_ptr->getIOStates().size(), 1u);
-  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->getIOStates(), stamped_msg.msg_.iOPinData(), /*start index*/ 0);
+  ASSERT_EQ(scan_ptr->ioStates().size(), 1u);
+  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->ioStates(), stamped_msg.msg_.iOPinData(), /*start index*/ 0);
 }
 
 /////////////////////////////////////////
@@ -310,10 +310,10 @@ TEST(LaserScanConversionsTest, laserScanShouldContainAllIOStates)
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
 
-  ASSERT_EQ(scan_ptr->getIOStates().size(), msg_count);
+  ASSERT_EQ(scan_ptr->ioStates().size(), msg_count);
   for (size_t i = 0; i < msg_count; i++)
   {
-    EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->getIOStates(), stamped_msgs.at(i).msg_.iOPinData(), /*start index*/ i);
+    EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->ioStates(), stamped_msgs.at(i).msg_.iOPinData(), /*start index*/ i);
   }
 }
 
@@ -327,10 +327,10 @@ TEST(LaserScanConversionsTest, laserScanShouldContainAllIOStatesInCorrectOrder)
   ASSERT_NO_THROW(
       scan_ptr.reset(new LaserScan{ data_conversion_layer::LaserScanConverter::toLaserScan(stamped_msgs) }););
 
-  ASSERT_EQ(scan_ptr->getIOStates().size(), msg_count);
-  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->getIOStates(), stamped_msgs.at(2).msg_.iOPinData(), /*scan start index*/ 0);
-  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->getIOStates(), stamped_msgs.at(1).msg_.iOPinData(), /*scan start index*/ 1);
-  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->getIOStates(), stamped_msgs.at(0).msg_.iOPinData(), /*scan start index*/ 2);
+  ASSERT_EQ(scan_ptr->ioStates().size(), msg_count);
+  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->ioStates(), stamped_msgs.at(2).msg_.iOPinData(), /*scan start index*/ 0);
+  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->ioStates(), stamped_msgs.at(1).msg_.iOPinData(), /*scan start index*/ 1);
+  EXPECT_IO_STATE_EQ_IO_PIN(scan_ptr->ioStates(), stamped_msgs.at(0).msg_.iOPinData(), /*scan start index*/ 2);
 }
 
 TEST(LaserScanConversionsTest, laserScanShouldContainActiveZonesetOfLastMsg)

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
@@ -24,10 +24,10 @@ TEST(MonitoringFrameDiagnosticMessageTest, shouldConstructMonitoringFrameDiagnos
 {
   auto msg = data_conversion_layer::monitoring_frame::diagnostic::Message(
       configuration::ScannerId::slave0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(4, 3));
-  EXPECT_EQ(msg.getDiagnosticCode(), data_conversion_layer::monitoring_frame::diagnostic::ErrorType::conf_err);
-  EXPECT_EQ(msg.getErrorLocation().byte(), static_cast<size_t>(4));
-  EXPECT_EQ(msg.getErrorLocation().bit(), static_cast<size_t>(3));
-  EXPECT_EQ(msg.getScannerId(), configuration::ScannerId::slave0);
+  EXPECT_EQ(msg.diagnosticCode(), data_conversion_layer::monitoring_frame::diagnostic::ErrorType::conf_err);
+  EXPECT_EQ(msg.errorLocation().byte(), static_cast<size_t>(4));
+  EXPECT_EQ(msg.errorLocation().bit(), static_cast<size_t>(3));
+  EXPECT_EQ(msg.scannerId(), configuration::ScannerId::slave0);
 }
 
 TEST(MonitoringFrameDiagnosticMessageTest, shouldBeEqualOnSameInputData)

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
@@ -25,8 +25,8 @@ TEST(MonitoringFrameDiagnosticMessageTest, shouldConstructMonitoringFrameDiagnos
   auto msg = data_conversion_layer::monitoring_frame::diagnostic::Message(
       configuration::ScannerId::slave0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(4, 3));
   EXPECT_EQ(msg.getDiagnosticCode(), data_conversion_layer::monitoring_frame::diagnostic::ErrorType::conf_err);
-  EXPECT_EQ(msg.getErrorLocation().getByte(), static_cast<size_t>(4));
-  EXPECT_EQ(msg.getErrorLocation().getBit(), static_cast<size_t>(3));
+  EXPECT_EQ(msg.getErrorLocation().byte(), static_cast<size_t>(4));
+  EXPECT_EQ(msg.getErrorLocation().bit(), static_cast<size_t>(3));
   EXPECT_EQ(msg.getScannerId(), configuration::ScannerId::slave0);
 }
 

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
@@ -135,7 +135,7 @@ TEST(MonitoringFrameSerializationTest, shouldSerializeAndDeserializeFrameConsist
 
   for (const auto& elem : error_locations)
   {
-    ASSERT_NE(monitoring_frame::diagnostic::ERROR_BITS.at(elem.getByte()).at(elem.getBit()),
+    ASSERT_NE(monitoring_frame::diagnostic::ERROR_BITS.at(elem.byte()).at(elem.bit()),
               monitoring_frame::diagnostic::ErrorType::unused)
         << "The unused diagnostic bits are discarded during deserialization. You should use different test data for "
            "this test.";

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -120,8 +120,8 @@ TEST_F(StartRequestTest, constructorTest)
   EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::speed_encoder_enabled), 0));
   EXPECT_TRUE(DecodingEquals<uint8_t>(data, static_cast<size_t>(Offset::diagnostics_enabled), 0));
 
-  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_start_angle), scan_range.getStart().value()));
-  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_end_angle), scan_range.getEnd().value()));
+  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_start_angle), scan_range.start().value()));
+  EXPECT_TRUE(DecodingEquals(data, static_cast<size_t>(Offset::master_end_angle), scan_range.end().value()));
   EXPECT_TRUE(DecodingEquals(
       data, static_cast<size_t>(Offset::master_angle_resolution), data_conversion_layer::degreeToTenthDegree(1.0)));
 
@@ -149,10 +149,10 @@ TEST_F(StartRequestTest, endAngleIncreasedWhenMatchingDataPoint)
   const auto raw_start_request{ data_conversion_layer::start_request::serialize(
       data_conversion_layer::start_request::Message(config)) };
 
-  EXPECT_TRUE(DecodingEquals(
-      raw_start_request, static_cast<size_t>(Offset::master_start_angle), scan_range.getStart().value()));
+  EXPECT_TRUE(
+      DecodingEquals(raw_start_request, static_cast<size_t>(Offset::master_start_angle), scan_range.start().value()));
   EXPECT_TRUE(DecodingEquals<uint16_t>(
-      raw_start_request, static_cast<size_t>(Offset::master_end_angle), scan_range.getEnd().value() + 1));
+      raw_start_request, static_cast<size_t>(Offset::master_end_angle), scan_range.end().value() + 1));
   EXPECT_TRUE(
       DecodingEquals(raw_start_request, static_cast<size_t>(Offset::master_angle_resolution), resolution.value()));
 }

--- a/test/include/psen_scan_v2/laserscan_validator.h
+++ b/test/include/psen_scan_v2/laserscan_validator.h
@@ -51,16 +51,16 @@ void addScanToBin(const psen_scan_v2_standalone::LaserScan& scan,
                   std::map<int16_t, NormalDist>& bin,
                   const int16_t angle_offset = 0)
 {
-  for (size_t i = 0; i < scan.getMeasurements().size(); ++i)
+  for (size_t i = 0; i < scan.measurements().size(); ++i)
   {
-    auto bin_addr = (scan.getMinScanAngle() + scan.getScanResolution() * i).value() + angle_offset;
+    auto bin_addr = (scan.minScanAngle() + scan.scanResolution() * i).value() + angle_offset;
 
     if (bin.find(bin_addr) == bin.end())
     {
       bin.emplace(bin_addr, NormalDist{});
       // Create bin
     }
-    bin[bin_addr].update(scan.getMeasurements()[i]);
+    bin[bin_addr].update(scan.measurements()[i]);
   }
 }
 

--- a/test/include/psen_scan_v2/ros_integrationtest_helper.h
+++ b/test/include/psen_scan_v2/ros_integrationtest_helper.h
@@ -117,7 +117,7 @@ bool isConnected(SubscriberMock<visualization_msgs::MarkerConstPtr>& subscriber,
   const auto start_time = ros::Time::now();
   while (ros::ok())
   {
-    if (subscriber.getSubscriber().getNumPublishers() > 0)
+    if (subscriber.subscriber().getNumPublishers() > 0)
     {
       return true;
     }

--- a/test/include/psen_scan_v2/subscriber_mock.h
+++ b/test/include/psen_scan_v2/subscriber_mock.h
@@ -34,7 +34,7 @@ public:
 
   MOCK_METHOD1_T(callback, void(const T& msg));
 
-  ros::Subscriber getSubscriber()
+  ros::Subscriber subscriber()
   {
     return subscriber_;
   }

--- a/test/include/psen_scan_v2/test_data.h
+++ b/test/include/psen_scan_v2/test_data.h
@@ -30,8 +30,7 @@ class TestDatum
 public:
   TestDatum(const uint32_t scan_counter, const int64_t timestamp, const int64_t callback_invocation_time);
 
-  void setFirstFrameTime(const int64_t first_frame_time);
-
+  void firstFrameTime(const int64_t first_frame_time);
   bool isComplete() const;
 
   uint32_t scanCounter() const;

--- a/test/include/psen_scan_v2/test_data_helper.h
+++ b/test/include/psen_scan_v2/test_data_helper.h
@@ -95,7 +95,7 @@ static void sortWithRespectToScanCounter(TestData& test_data)
 
 static void extractDataFromScan(TestData& test_data, const LaserScan& scan)
 {
-  test_data.push_back(TestDatum(scan.getScanCounter(), scan.getTimestamp(), util::getCurrentTime()));
+  test_data.push_back(TestDatum(scan.scanCounter(), scan.timestamp(), util::getCurrentTime()));
 }
 
 static std::unique_ptr<TestData> assemble(const ScannerConfiguration& scanner_config,

--- a/test/include/psen_scan_v2/test_data_helper.h
+++ b/test/include/psen_scan_v2/test_data_helper.h
@@ -73,7 +73,7 @@ static void addUdpData(TestData& test_data, const udp_data::UdpData& udp_data)
       });
       if (it != test_data.end())
       {
-        it->setFirstFrameTime(secToNSec(udp_datum.timestamp_sec_));
+        it->firstFrameTime(secToNSec(udp_datum.timestamp_sec_));
       }
     }
   }

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -242,9 +242,9 @@ TEST_F(RosScannerNodeTests, shouldPublishIOStatesEqualToConversionOfSuppliedStan
   SubscriberMock<psen_scan_v2::IOState> subscriber(nh_priv_, "io_state", QUEUE_SIZE);
   {
     InSequence s;
-    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA1.at(0), prefix, scan.getTimestamp())))).Times(1);
-    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA1.at(1), prefix, scan.getTimestamp())))).Times(1);
-    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA2.at(0), prefix, scan.getTimestamp()))))
+    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA1.at(0), prefix, scan.timestamp())))).Times(1);
+    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA1.at(1), prefix, scan.timestamp())))).Times(1);
+    EXPECT_CALL(subscriber, callback(IOStateMsgEq(toIOStateMsg(IO_DATA2.at(0), prefix, scan.timestamp()))))
         .WillOnce(OpenBarrier(&io_topic_barrier));
   }
 

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -254,9 +254,9 @@ TEST_F(RosScannerNodeTests, shouldPublishIOStatesEqualToConversionOfSuppliedStan
   std::future<void> loop = std::async(std::launch::async, [&ros_scanner_node]() { ros_scanner_node.run(); });
   ASSERT_BARRIER_OPENS(start_barrier, DEFAULT_TIMEOUT) << "Scanner start was not called";
 
-  scan.setIOStates(IO_DATA1);
+  scan.ioStates(IO_DATA1);
   ros_scanner_node.scanner_.invokeLaserScanCallback(scan);
-  scan.setIOStates(IO_DATA2);
+  scan.ioStates(IO_DATA2);
   ros_scanner_node.scanner_.invokeLaserScanCallback(scan);
   io_topic_barrier.waitTillRelease(DEFAULT_TIMEOUT);
 

--- a/test/src/test_data.cpp
+++ b/test/src/test_data.cpp
@@ -28,7 +28,7 @@ TestDatum::TestDatum(const uint32_t scan_counter, const int64_t timestamp, const
 {
 }
 
-void TestDatum::setFirstFrameTime(const int64_t first_frame_time)
+void TestDatum::firstFrameTime(const int64_t first_frame_time)
 {
   first_frame_time_ = first_frame_time;
 }

--- a/test/unit_tests/unittest_laserscan_ros_conversions.cpp
+++ b/test/unit_tests/unittest_laserscan_ros_conversions.cpp
@@ -42,10 +42,10 @@ static LaserScan createScan(int64_t stamp = 1)
 
   LaserScan laserscan(angle_increment, angle_min_raw, angle_max_raw, scan_counter, active_zoneset, timestamp);
   const LaserScan::MeasurementData measurements{ 1., 2., 3. };
-  laserscan.setMeasurements(measurements);
+  laserscan.measurements(measurements);
 
   const LaserScan::IntensityData intensities{ 707., 304., 0. };
-  laserscan.setIntensities(intensities);
+  laserscan.intensities(intensities);
 
   return laserscan;
 }
@@ -57,7 +57,7 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectHeaderAfterC
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, prefix, 0);
 
   EXPECT_EQ(laserscan_msg.header.seq, 0u);
-  EXPECT_EQ(static_cast<int64_t>(laserscan_msg.header.stamp.toNSec()), laserscan.getTimestamp());
+  EXPECT_EQ(static_cast<int64_t>(laserscan_msg.header.stamp.toNSec()), laserscan.timestamp());
   EXPECT_EQ(laserscan_msg.header.frame_id, prefix);
 }
 
@@ -66,7 +66,7 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectScanResoluti
   const LaserScan laserscan{ createScan() };
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, "", 0);
 
-  EXPECT_NEAR(laserscan_msg.angle_increment, laserscan.getScanResolution().toRad(), EPSILON)
+  EXPECT_NEAR(laserscan_msg.angle_increment, laserscan.scanResolution().toRad(), EPSILON)
       << "Resolution incorrect in sensor_msgs::LaserScan";
 }
 
@@ -76,8 +76,8 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectMinMaxScanAn
   constexpr double x_axis_rotation{ 0 };
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, "", x_axis_rotation);
 
-  EXPECT_NEAR(laserscan_msg.angle_min, laserscan.getMinScanAngle().toRad() - x_axis_rotation, EPSILON);
-  EXPECT_NEAR(laserscan_msg.angle_max, laserscan.getMaxScanAngle().toRad() - x_axis_rotation, EPSILON);
+  EXPECT_NEAR(laserscan_msg.angle_min, laserscan.minScanAngle().toRad() - x_axis_rotation, EPSILON);
+  EXPECT_NEAR(laserscan_msg.angle_max, laserscan.maxScanAngle().toRad() - x_axis_rotation, EPSILON);
 }
 
 TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectTimePerRadAfterConversion)
@@ -86,7 +86,7 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectTimePerRadAf
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, "", 0);
 
   const double time_per_rad = configuration::TIME_PER_SCAN_IN_S / (2 * M_PI);  // angle speed
-  EXPECT_NEAR(laserscan_msg.time_increment, time_per_rad * laserscan.getScanResolution().toRad(), EPSILON);
+  EXPECT_NEAR(laserscan_msg.time_increment, time_per_rad * laserscan.scanResolution().toRad(), EPSILON);
 }
 
 TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectMinMaxRangeAfterConversion)
@@ -109,11 +109,11 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectRangesAfterC
   const LaserScan laserscan{ createScan() };
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, "", 0);
 
-  ASSERT_EQ(laserscan_msg.ranges.size(), laserscan.getMeasurements().size());
+  ASSERT_EQ(laserscan_msg.ranges.size(), laserscan.measurements().size());
   // Check that the ranges in the ROS msg is the same order as the laserscan and given in meters
   for (size_t i = 0; i < laserscan_msg.ranges.size(); ++i)
   {
-    EXPECT_NEAR(laserscan_msg.ranges.at(i), laserscan.getMeasurements().at(i), EPSILON);
+    EXPECT_NEAR(laserscan_msg.ranges.at(i), laserscan.measurements().at(i), EPSILON);
   }
 }
 
@@ -122,10 +122,10 @@ TEST(LaserScanROSConversionsTest, laserSensorMsgShouldContainCorrectIntensitiesA
   const LaserScan laserscan{ createScan() };
   const sensor_msgs::LaserScan laserscan_msg = toLaserScanMsg(laserscan, "", 0);
 
-  ASSERT_EQ(laserscan_msg.intensities.size(), laserscan.getIntensities().size());
+  ASSERT_EQ(laserscan_msg.intensities.size(), laserscan.intensities().size());
   for (size_t i = 0; i < laserscan_msg.intensities.size(); ++i)
   {
-    EXPECT_NEAR(laserscan_msg.intensities.at(i), laserscan.getIntensities().at(i), EPSILON);
+    EXPECT_NEAR(laserscan_msg.intensities.at(i), laserscan.intensities().at(i), EPSILON);
   }
 }
 


### PR DESCRIPTION
## Description

LaserScan uses getX and setX naming while most of the other classes just use X we should unify this naming. The old getters and setters are now deprecated.


### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [x] ~Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] ~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~
- [x] ~Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))~
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] ~Documentation describes purpose of file(s) and responsibilities~
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~When is the new feature released?~
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
