### PR TITLE
Renaming Slave to Subscriber 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Forthcoming
 ------------------
 * Add IO state to LaserScan
 * Publish IO states to ~/io_state
+* Renaming Slave to Subscriber
 * Contributors: Pilz GmbH and Co. KG
 
 0.3.4 (2021-12-20)

--- a/standalone/include/psen_scan_v2_standalone/configuration/scanner_ids.h
+++ b/standalone/include/psen_scan_v2_standalone/configuration/scanner_ids.h
@@ -27,20 +27,20 @@ namespace configuration
 enum class ScannerId : uint8_t
 {
   master = 0,
-  slave0 = 1,
-  slave1 = 2,
-  slave2 = 3
+  subscriber0 = 1,  // Note: This refers to the scanner type subscriber, *not* a ros subscriber
+  subscriber1 = 2,
+  subscriber2 = 3
 };
 
 static constexpr std::array<ScannerId, 4> VALID_SCANNER_IDS{ ScannerId::master,
-                                                             ScannerId::slave0,
-                                                             ScannerId::slave1,
-                                                             ScannerId::slave2 };
+                                                             ScannerId::subscriber0,
+                                                             ScannerId::subscriber1,
+                                                             ScannerId::subscriber2 };
 
 static const std::map<ScannerId, std::string> SCANNER_ID_TO_STRING{ { ScannerId::master, "Master" },
-                                                                    { ScannerId::slave0, "Slave0" },
-                                                                    { ScannerId::slave1, "Slave1" },
-                                                                    { ScannerId::slave2, "Slave2" } };
+                                                                    { ScannerId::subscriber0, "Subscriber0" },
+                                                                    { ScannerId::subscriber1, "Subscriber1" },
+                                                                    { ScannerId::subscriber2, "Subscriber2" } };
 
 }  // namespace configuration
 }  // namespace psen_scan_v2_standalone

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/start_request.h
@@ -49,7 +49,7 @@ public:
 
 private:
   /**
-   * @brief Class describing the scan settings of the master and slave devices.
+   * @brief Class describing the scan settings of the master and subscriber devices.
    *
    * The settings include the scan range and the scan resolution of the respective device.
    */
@@ -69,7 +69,7 @@ private:
   };
 
   /**
-   * @brief Class describing the fundamental settings of the master and slave devices, like id and diagnostics.
+   * @brief Class describing the fundamental settings of the master and subscriber devices, like id and diagnostics.
    */
   class DeviceSettings
   {
@@ -86,7 +86,7 @@ private:
   };
 
 private:
-  static constexpr std::size_t NUM_SLAVES{ 3 };
+  static constexpr std::size_t NUM_SUBSCRIBERS{ 3 };
 
 private:
   const uint32_t host_ip_;  ///< network byte order = big endian
@@ -94,7 +94,8 @@ private:
 
   const DeviceSettings master_device_settings_;
   const LaserScanSettings master_;
-  const std::array<LaserScanSettings, NUM_SLAVES> slaves_;
+  const std::array<LaserScanSettings, NUM_SUBSCRIBERS> subscribers_;  // Note: This refers to the scanner type
+                                                                      // subscriber, *not* a ros subscriber
 };
 
 constexpr Message::LaserScanSettings::LaserScanSettings(const ScanRange& scan_range,

--- a/standalone/src/data_conversion_layer/start_request_serialization.cpp
+++ b/standalone/src/data_conversion_layer/start_request_serialization.cpp
@@ -75,7 +75,7 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
   /**< The following 'enable' fields are a 1-byte mask each.
    * Only the last 4 bits (little endian) are used, each of which represents a device.
    * For example, (1000) only enables the Master device, while (1010) enables both the Master
-   * and the second Slave device.
+   * and the second Subscriber device.
    */
 
   const uint8_t device_enabled{ 0b00001000 };
@@ -118,11 +118,12 @@ RawData data_conversion_layer::start_request::serialize(const data_conversion_la
                  end,
                  resolution);
 
-  for (const auto& slave : msg.slaves_)
+  for (const auto& subscriber :
+       msg.subscribers_)  // Note: This refers to the scanner type subscriber, *not* a ros subscriber
   {
-    raw_processing::write(os, slave.getScanRange().getStart().value());
-    raw_processing::write(os, slave.getScanRange().getEnd().value());
-    raw_processing::write(os, slave.getResolution().value());
+    raw_processing::write(os, subscriber.getScanRange().getStart().value());
+    raw_processing::write(os, subscriber.getScanRange().getEnd().value());
+    raw_processing::write(os, subscriber.getResolution().value());
   }
 
   const std::string raw_data_as_str{ os.str() };

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_diagnostic_message.cpp
@@ -23,46 +23,46 @@ namespace psen_scan_v2_standalone_test
 TEST(MonitoringFrameDiagnosticMessageTest, shouldConstructMonitoringFrameDiagnosticMessageAsExpected)
 {
   auto msg = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(4, 3));
+      configuration::ScannerId::subscriber0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(4, 3));
   EXPECT_EQ(msg.getDiagnosticCode(), data_conversion_layer::monitoring_frame::diagnostic::ErrorType::conf_err);
   EXPECT_EQ(msg.getErrorLocation().getByte(), static_cast<size_t>(4));
   EXPECT_EQ(msg.getErrorLocation().getBit(), static_cast<size_t>(3));
-  EXPECT_EQ(msg.getScannerId(), configuration::ScannerId::slave0);
+  EXPECT_EQ(msg.getScannerId(), configuration::ScannerId::subscriber0);
 }
 
 TEST(MonitoringFrameDiagnosticMessageTest, shouldBeEqualOnSameInputData)
 {
   auto msg0 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
   auto msg1 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
   EXPECT_EQ(msg0, msg1);
 }
 
 TEST(MonitoringFrameDiagnosticMessageTest, shouldBeNotEqualOnDifferentScannerId)
 {
   auto msg0 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
+      configuration::ScannerId::subscriber0, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
   auto msg1 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(3, 0));
   EXPECT_FALSE(msg0 == msg1);
 }
 
 TEST(MonitoringFrameDiagnosticMessageTest, shouldBeNotEqualOnErrorByteLocation)
 {
   auto msg0 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(0, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(0, 0));
   auto msg1 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 0));
   EXPECT_FALSE(msg0 == msg1);
 }
 
 TEST(MonitoringFrameDiagnosticMessageTest, shouldBeNotEqualOnDifferentErrorBitLocation)
 {
   auto msg0 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 0));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 0));
   auto msg1 = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 1));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(1, 1));
   EXPECT_FALSE(msg0 == msg1);
 }
 
@@ -78,12 +78,12 @@ TEST(MonitoringFrameDiagnosticMessageTest, shouldOutputTheRightDiagnosticMessage
 TEST(MonitoringFrameDiagnosticMessageTest, shouldOutputTheRightDiagnosticMessageWithBitandBytes)
 {
   auto msg = data_conversion_layer::monitoring_frame::diagnostic::Message(
-      configuration::ScannerId::slave1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(2, 5));
+      configuration::ScannerId::subscriber1, data_conversion_layer::monitoring_frame::diagnostic::ErrorLocation(2, 5));
   std::ostringstream os;
   os << msg;
 
   // Output with byte/bit information since error internal error is ambiguous
-  EXPECT_EQ(os.str(), "Device: Slave1 - Internal error. (Byte:2 Bit:5)");
+  EXPECT_EQ(os.str(), "Device: Subscriber1 - Internal error. (Byte:2 Bit:5)");
 }
 }  // namespace psen_scan_v2_standalone_test
 

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_msg.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_msg.cpp
@@ -113,7 +113,7 @@ TEST(MonitoringFrameMsgTest, shouldReturnCorrectStateOfIOPin)
 
 TEST(MonitoringFrameMsgTest, shouldReturnCorrectScannerId)
 {
-  const auto scanner_id{ configuration::ScannerId::slave0 };
+  const auto scanner_id{ configuration::ScannerId::subscriber0 };
   EXPECT_EQ(scanner_id, MessageBuilder().scannerId(scanner_id).build().scannerId());
 }
 

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
@@ -145,19 +145,20 @@ TEST(MonitoringFrameSerializationTest, shouldSerializeAndDeserializeFrameConsist
   setInputPin(pin_data, LogicalInputType::muting_1_a);
   setOutputPin(pin_data, OutputType::safe_1_int);
 
-  auto msg = monitoring_frame::MessageBuilder()
-                 .fromTheta(util::TenthOfDegree(25))
-                 .resolution(util::TenthOfDegree(1))
-                 .scanCounter(456)
-                 .activeZoneset(2)
-                 .measurements({ 10, 20, std::numeric_limits<double>::infinity(), 40 })
-                 .intensities({ 15, 25, 35, 45 })
-                 .iOPinData(pin_data)
-                 .diagnosticMessages(
-                     { monitoring_frame::diagnostic::Message(configuration::ScannerId::master, error_locations.at(0)),
-                       monitoring_frame::diagnostic::Message(configuration::ScannerId::master, error_locations.at(1)),
-                       monitoring_frame::diagnostic::Message(configuration::ScannerId::slave2, error_locations.at(2)) })
-                 .build();
+  auto msg =
+      monitoring_frame::MessageBuilder()
+          .fromTheta(util::TenthOfDegree(25))
+          .resolution(util::TenthOfDegree(1))
+          .scanCounter(456)
+          .activeZoneset(2)
+          .measurements({ 10, 20, std::numeric_limits<double>::infinity(), 40 })
+          .intensities({ 15, 25, 35, 45 })
+          .iOPinData(pin_data)
+          .diagnosticMessages(
+              { monitoring_frame::diagnostic::Message(configuration::ScannerId::master, error_locations.at(0)),
+                monitoring_frame::diagnostic::Message(configuration::ScannerId::master, error_locations.at(1)),
+                monitoring_frame::diagnostic::Message(configuration::ScannerId::subscriber2, error_locations.at(2)) })
+          .build();
 
   auto raw = serialize(msg);
   auto deserialized_msg = monitoring_frame::deserialize(convertToRawData(raw), raw.size());

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_start_request.cpp
@@ -54,15 +54,15 @@ public:
     master_start_angle = 0x22,
     master_end_angle = 0x24,
     master_angle_resolution = 0x26,
-    slave_one_start_angle = 0x28,
-    slave_one_end_angle = 0x2A,
-    slave_one_angle_resolution = 0x2C,
-    slave_two_start_angle = 0x2E,
-    slave_two_end_angle = 0x30,
-    slave_two_angle_resolution = 0x32,
-    slave_three_start_angle = 0x34,
-    slave_three_end_angle = 0x36,
-    slave_three_angle_resolution = 0x38
+    subscriber_one_start_angle = 0x28,  // Note: This refers to the scanner type subscriber, *not* a ros subscriber
+    subscriber_one_end_angle = 0x2A,
+    subscriber_one_angle_resolution = 0x2C,
+    subscriber_two_start_angle = 0x2E,
+    subscriber_two_end_angle = 0x30,
+    subscriber_two_angle_resolution = 0x32,
+    subscriber_three_start_angle = 0x34,
+    subscriber_three_end_angle = 0x36,
+    subscriber_three_angle_resolution = 0x38
   };
 };
 
@@ -125,15 +125,15 @@ TEST_F(StartRequestTest, constructorTest)
   EXPECT_TRUE(DecodingEquals(
       data, static_cast<size_t>(Offset::master_angle_resolution), data_conversion_layer::degreeToTenthDegree(1.0)));
 
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_one_start_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_one_end_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_one_angle_resolution), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_two_start_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_two_end_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_two_angle_resolution), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_three_start_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_three_end_angle), 0));
-  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::slave_three_angle_resolution), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_one_start_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_one_end_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_one_angle_resolution), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_two_start_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_two_end_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_two_angle_resolution), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_three_start_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_three_end_angle), 0));
+  EXPECT_TRUE(DecodingEquals<uint16_t>(data, static_cast<size_t>(Offset::subscriber_three_angle_resolution), 0));
 }
 
 TEST_F(StartRequestTest, endAngleIncreasedWhenMatchingDataPoint)


### PR DESCRIPTION
## Description

This changes all occurrences of slave to subscriber. 
It is the new name for the slave models of PSENscan.
At important places comments were added to avoid confusion with the ros-internal meaning of subscriber.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
- [x] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [x] Examples

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
- [x] Which dependent packages do have to be released simultaneously?

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
