### PR TITLE
Move IOState implementation to io_state.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ include_directories(
 
 set(${PROJECT_NAME}_standalone_sources
   standalone/src/scanner_v2.cpp
+  standalone/src/io_state.cpp
   standalone/src/laserscan.cpp
   standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
   standalone/src/data_conversion_layer/start_request.cpp
@@ -337,6 +338,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(unittest_laserscan
     standalone/test/unit_tests/api/unittest_laserscan.cpp
+    standalone/src/io_state.cpp
     standalone/src/laserscan.cpp
   )
   target_link_libraries(unittest_laserscan
@@ -346,6 +348,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(unittest_pin_state
     standalone/test/unit_tests/api/unittest_pin_state.cpp
+    standalone/src/io_state.cpp
   )
   target_link_libraries(unittest_pin_state
     ${catkin_LIBRARIES}
@@ -354,6 +357,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(unittest_io_state
     standalone/test/unit_tests/api/unittest_io_state.cpp
+    standalone/src/io_state.cpp
   )
   target_link_libraries(unittest_io_state
     ${catkin_LIBRARIES}
@@ -362,6 +366,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gmock(unittest_laserscan_conversions
     standalone/test/unit_tests/data_conversion_layer/unittest_laserscan_conversions.cpp
+    standalone/src/io_state.cpp
     standalone/src/laserscan.cpp
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
@@ -373,6 +378,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(unittest_laserscan_ros_conversions
     test/unit_tests/unittest_laserscan_ros_conversions.cpp
+    standalone/src/io_state.cpp
     standalone/src/laserscan.cpp
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
@@ -396,6 +402,7 @@ if(CATKIN_ENABLE_TESTING)
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
     standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
+    standalone/src/io_state.cpp
   )
   target_link_libraries(unittest_monitoring_frame_msg
     ${catkin_LIBRARIES}
@@ -406,6 +413,7 @@ if(CATKIN_ENABLE_TESTING)
     standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_msg_stamped.cpp
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
+    standalone/src/io_state.cpp
   )
   target_link_libraries(unittest_monitoring_frame_msg_stamped
     ${catkin_LIBRARIES}
@@ -416,6 +424,7 @@ if(CATKIN_ENABLE_TESTING)
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
+    standalone/src/io_state.cpp
     standalone/test/unit_tests/data_conversion_layer/unittest_monitoring_frame_serialization_deserialization.cpp
     standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
   )
@@ -471,6 +480,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gmock(unittest_io_state_rosconversions
     test/unit_tests/unittest_io_state_rosconversions.cpp
+    standalone/src/io_state.cpp
   )
   target_link_libraries(unittest_io_state_rosconversions
     ${catkin_LIBRARIES}
@@ -506,6 +516,7 @@ if(CATKIN_ENABLE_TESTING)
     standalone/test/src/communication_layer/scanner_mock.cpp
     standalone/test/src/data_conversion_layer/monitoring_frame_serialization.cpp
     standalone/src/scanner_v2.cpp
+    standalone/src/io_state.cpp
     standalone/src/laserscan.cpp
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/monitoring_frame_deserialization.cpp
@@ -523,6 +534,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gmock(integrationtest_ros_scanner_node
     test/integration_tests/integrationtest_ros_scanner_node.test
     test/integration_tests/integrationtest_ros_scanner_node.cpp
+    standalone/src/io_state.cpp
     standalone/src/laserscan.cpp
     standalone/src/data_conversion_layer/monitoring_frame_msg.cpp
     standalone/src/data_conversion_layer/diagnostics.cpp
@@ -660,14 +672,12 @@ if(CATKIN_ENABLE_TESTING)
 
     catkin_add_gtest(hwtest_scan_compare_standalone
       test/hw_tests/hwtest_scan_compare_standalone.cpp
-      standalone/src/laserscan.cpp
     )
 
   else()
     # always at least build the test to avoid build breaking changes
     catkin_add_executable_with_gtest(hwtest_scan_compare_standalone
                                             test/hw_tests/hwtest_scan_compare_standalone.cpp
-                                            standalone/src/laserscan.cpp
                                             EXCLUDE_FROM_ALL)
     add_dependencies(tests hwtest_scan_compare_standalone)
 
@@ -690,6 +700,7 @@ if(CATKIN_ENABLE_TESTING)
     add_rostest_gtest(hwtest_scan_compare
       test/hw_tests/hwtest_scan_compare.test
       test/hw_tests/hwtest_scan_compare.cpp
+      standalone/src/io_state.cpp
       standalone/src/laserscan.cpp
     )
     add_dependencies(hwtest_scan_compare
@@ -701,6 +712,7 @@ if(CATKIN_ENABLE_TESTING)
     # always at least build the test to avoid build breaking changes
     catkin_add_executable_with_gtest(hwtest_scan_compare
       test/hw_tests/hwtest_scan_compare.cpp
+      standalone/src/io_state.cpp
       standalone/src/laserscan.cpp
       EXCLUDE_FROM_ALL
     )

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -56,6 +56,7 @@ include_directories(
 
 set(${PROJECT_NAME}_sources
   src/scanner_v2.cpp
+  src/io_state.cpp
   src/laserscan.cpp
   src/data_conversion_layer/monitoring_frame_msg.cpp
   src/data_conversion_layer/start_request.cpp
@@ -320,16 +321,7 @@ add_executable(integrationtest_scanner_api
         test/integration_tests/api/integrationtest_scanner_api.cpp
         test/src/communication_layer/mock_udp_server.cpp
         test/src/communication_layer/scanner_mock.cpp
-        test/src/data_conversion_layer/monitoring_frame_serialization.cpp
-        src/scanner_v2.cpp
-        src/laserscan.cpp
-        src/data_conversion_layer/monitoring_frame_msg.cpp
-        src/data_conversion_layer/monitoring_frame_deserialization.cpp
-        src/data_conversion_layer/start_request.cpp
-        src/data_conversion_layer/stop_request_serialization.cpp
-        src/data_conversion_layer/diagnostics.cpp
-        src/data_conversion_layer/start_request_serialization.cpp
-        src/data_conversion_layer/scanner_reply_serialization_deserialization.cpp)
+        test/src/data_conversion_layer/monitoring_frame_serialization.cpp)
 
 target_link_libraries(integrationtest_scanner_api
     ${PROJECT_NAME}

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/io_pin_data.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/io_pin_data.h
@@ -17,13 +17,18 @@
 #define PSEN_SCAN_V2_STANDALONE_IO_PIN_H
 
 #include <functional>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 #include "psen_scan_v2_standalone/data_conversion_layer/io_constants.h"
 #include "psen_scan_v2_standalone/io_state.h"
+#include "psen_scan_v2_standalone/util/format_range.h"
 
 namespace psen_scan_v2_standalone
 {

--- a/standalone/include/psen_scan_v2_standalone/io_state.h
+++ b/standalone/include/psen_scan_v2_standalone/io_state.h
@@ -16,14 +16,9 @@
 #ifndef PSEN_SCAN_V2_STANDALONE_IO_STATE_H
 #define PSEN_SCAN_V2_STANDALONE_IO_STATE_H
 
+#include <ostream>
 #include <string>
-#include <utility>
 #include <vector>
-
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
-#include "psen_scan_v2_standalone/util/format_range.h"
 
 namespace psen_scan_v2_standalone
 {
@@ -49,43 +44,7 @@ private:
   bool state_;
 };
 
-inline PinState::PinState(uint32_t pin_id, const std::string& name, bool state)
-  : id_(pin_id), name_(name), state_(state)
-{
-}
-
-inline bool PinState::operator==(const PinState& ps) const
-{
-  return id() == ps.id() && name() == ps.name() && state() == ps.state();
-}
-
-inline bool PinState::operator!=(const PinState& ps) const
-{
-  return !operator==(ps);
-}
-
-inline uint32_t PinState::id() const
-{
-  return id_;
-}
-
-inline std::string PinState::name() const
-{
-  return name_;
-}
-
-inline bool PinState::state() const
-{
-  return state_;
-}
-
-// LCOV_EXCL_START
-inline std::ostream& operator<<(std::ostream& os, const PinState& pin_state)
-{
-  return os << fmt::format(
-             "PinState(id = {}, name = {}, state = {})", pin_state.id(), pin_state.name(), pin_state.state());
-}
-// LCOV_EXCL_STOP
+std::ostream& operator<<(std::ostream& os, const PinState& pin_state);
 
 //! @brief Represents the set of all I/Os of the scanner and their states.
 class IOState
@@ -101,27 +60,7 @@ private:
   std::vector<PinState> output_{};
 };
 
-inline IOState::IOState(std::vector<PinState> input, std::vector<PinState> output)
-  : input_(std::move(input)), output_(std::move(output))
-{
-}
-
-inline const std::vector<PinState>& IOState::input() const
-{
-  return input_;
-}
-
-inline const std::vector<PinState>& IOState::output() const
-{
-  return output_;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const IOState& io_state)
-{
-  return os << fmt::format("IOState(input = {}, output = {})",
-                           util::formatRange(io_state.input()),
-                           util::formatRange(io_state.output()));
-}
+std::ostream& operator<<(std::ostream& os, const IOState& io_state);
 }  // namespace psen_scan_v2_standalone
 
 #endif  // PSEN_SCAN_V2_STANDALONE_IO_STATE_H

--- a/standalone/src/io_state.cpp
+++ b/standalone/src/io_state.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Pilz GmbH & Co. KG
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include "psen_scan_v2_standalone/io_state.h"
+#include "psen_scan_v2_standalone/util/format_range.h"
+
+namespace psen_scan_v2_standalone
+{
+PinState::PinState(uint32_t pin_id, const std::string& name, bool state) : id_(pin_id), name_(name), state_(state)
+{
+}
+
+bool PinState::operator==(const PinState& ps) const
+{
+  return id() == ps.id() && name() == ps.name() && state() == ps.state();
+}
+
+bool PinState::operator!=(const PinState& ps) const
+{
+  return !operator==(ps);
+}
+
+uint32_t PinState::id() const
+{
+  return id_;
+}
+
+std::string PinState::name() const
+{
+  return name_;
+}
+
+bool PinState::state() const
+{
+  return state_;
+}
+
+std::ostream& operator<<(std::ostream& os, const PinState& pin_state)
+{
+  return os << fmt::format(  // LCOV_EXCL_LINE lcov bug?
+             "PinState(id = {}, name = {}, state = {})",
+             pin_state.id(),
+             pin_state.name(),
+             pin_state.state());
+}
+
+IOState::IOState(std::vector<PinState> input, std::vector<PinState> output)
+  : input_(std::move(input)), output_(std::move(output))
+{
+}
+
+const std::vector<PinState>& IOState::input() const
+{
+  return input_;
+}
+
+const std::vector<PinState>& IOState::output() const
+{
+  return output_;
+}
+
+std::ostream& operator<<(std::ostream& os, const IOState& io_state)
+{
+  return os << fmt::format("IOState(input = {}, output = {})",
+                           util::formatRange(io_state.input()),
+                           util::formatRange(io_state.output()));
+}
+}  // namespace psen_scan_v2_standalone


### PR DESCRIPTION
Internal refactoring: These changes prepare #301, where we move parts of the `IOState` implementation to a separate header.