### PR TITLE
Remove zoneset bits and update tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package psen_scan_v2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Forthcoming
+------------------
+* Remove zoneset bits from IOState.input field since its redundant to the active_zoneset field (#311)
 
 0.10.0 (2022-01-20)
 -------------------

--- a/standalone/include/psen_scan_v2_standalone/data_conversion_layer/io_constants.h
+++ b/standalone/include/psen_scan_v2_standalone/data_conversion_layer/io_constants.h
@@ -87,14 +87,6 @@ using Lit = LogicalInputType;
 using IoName = std::string;
 // clang-format off
 static const std::map<Lit, IoName> LOGICAL_INPUT_BIT_TO_NAME{
-  { Lit::zone_bit_0, "Zone Bit 0" },
-  { Lit::zone_bit_1, "Zone Bit 1" },
-  { Lit::zone_bit_2, "Zone Bit 2" },
-  { Lit::zone_bit_3, "Zone Bit 3" },
-  { Lit::zone_bit_4, "Zone Bit 4" },
-  { Lit::zone_bit_5, "Zone Bit 5" },
-  { Lit::zone_bit_6, "Zone Bit 6" },
-  { Lit::zone_bit_7, "Zone Bit 7" },
 
   { Lit::zone_sw_2, "Zone Set Switching Input 2" },
   { Lit::zone_sw_1, "Zone Set Switching Input 1" },
@@ -125,7 +117,7 @@ static const std::map<Lit, IoName> LOGICAL_INPUT_BIT_TO_NAME{
 
 static constexpr std::array<std::array<Lit, 8>, RAW_CHUNK_LOGICAL_INPUT_SIGNALS_IN_BYTES> LOGICAL_INPUT_BITS{{
   //    Bit7                Bit6             Bit5              Bit4             Bit3               Bit2                Bit1             Bit0
-  { REV(Lit::zone_bit_7,    Lit::zone_bit_6, Lit::zone_bit_5,  Lit::zone_bit_4, Lit::zone_bit_3,   Lit::zone_bit_2,    Lit::zone_bit_1, Lit::zone_bit_0) },
+  {     Lit::unused,        Lit::unused,     Lit::unused,      Lit::unused,     Lit::unused,       Lit::unused,        Lit::unused,     Lit::unused },
   {     Lit::unused,        Lit::unused,     Lit::unused,      Lit::unused,     Lit::unused,       Lit::unused,        Lit::unused,     Lit::unused },
   {     Lit::unused,        Lit::unused,     Lit::unused,      Lit::unused,     Lit::unused,       Lit::unused,        Lit::unused,     Lit::unused },
   {     Lit::unused,        Lit::unused,     Lit::unused,      Lit::unused,     Lit::unused,       Lit::unused,        Lit::unused,     Lit::unused },

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_io_pin_data.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_io_pin_data.cpp
@@ -24,17 +24,10 @@ using namespace psen_scan_v2_standalone::data_conversion_layer::monitoring_frame
 
 TEST(IOPinDataTest, shouldReturnCorrectInputType)
 {
-  EXPECT_EQ(getInputType(0, 0), LogicalInputType::zone_bit_0);
-  EXPECT_EQ(getInputType(0, 1), LogicalInputType::zone_bit_1);
-  EXPECT_EQ(getInputType(0, 2), LogicalInputType::zone_bit_2);
-  EXPECT_EQ(getInputType(0, 3), LogicalInputType::zone_bit_3);
-  EXPECT_EQ(getInputType(0, 4), LogicalInputType::zone_bit_4);
-  EXPECT_EQ(getInputType(0, 5), LogicalInputType::zone_bit_5);
-  EXPECT_EQ(getInputType(0, 6), LogicalInputType::zone_bit_6);
-  EXPECT_EQ(getInputType(0, 7), LogicalInputType::zone_bit_7);
 
   for (std::size_t bit_n = 0; bit_n < 8; ++bit_n)
   {
+    EXPECT_EQ(getInputType(0, bit_n), LogicalInputType::unused);
     EXPECT_EQ(getInputType(1, bit_n), LogicalInputType::unused);
     EXPECT_EQ(getInputType(2, bit_n), LogicalInputType::unused);
     EXPECT_EQ(getInputType(3, bit_n), LogicalInputType::unused);
@@ -76,17 +69,10 @@ TEST(IOPinDataTest, shouldReturnCorrectInputType)
 
 TEST(IOPinDataTest, shouldReturnCorrectInputName)
 {
-  EXPECT_EQ(getInputName(0, 0), "Zone Bit 0");
-  EXPECT_EQ(getInputName(0, 1), "Zone Bit 1");
-  EXPECT_EQ(getInputName(0, 2), "Zone Bit 2");
-  EXPECT_EQ(getInputName(0, 3), "Zone Bit 3");
-  EXPECT_EQ(getInputName(0, 4), "Zone Bit 4");
-  EXPECT_EQ(getInputName(0, 5), "Zone Bit 5");
-  EXPECT_EQ(getInputName(0, 6), "Zone Bit 6");
-  EXPECT_EQ(getInputName(0, 7), "Zone Bit 7");
 
   for (std::size_t bit_n = 0; bit_n < 8; ++bit_n)
   {
+    EXPECT_EQ(getInputName(0, bit_n), "unused");
     EXPECT_EQ(getInputName(1, bit_n), "unused");
     EXPECT_EQ(getInputName(2, bit_n), "unused");
     EXPECT_EQ(getInputName(3, bit_n), "unused");

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_io_pin_data.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_io_pin_data.cpp
@@ -24,7 +24,6 @@ using namespace psen_scan_v2_standalone::data_conversion_layer::monitoring_frame
 
 TEST(IOPinDataTest, shouldReturnCorrectInputType)
 {
-
   for (std::size_t bit_n = 0; bit_n < 8; ++bit_n)
   {
     EXPECT_EQ(getInputType(0, bit_n), LogicalInputType::unused);
@@ -69,7 +68,6 @@ TEST(IOPinDataTest, shouldReturnCorrectInputType)
 
 TEST(IOPinDataTest, shouldReturnCorrectInputName)
 {
-
   for (std::size_t bit_n = 0; bit_n < 8; ++bit_n)
   {
     EXPECT_EQ(getInputName(0, bit_n), "unused");

--- a/standalone/test/unit_tests/data_conversion_layer/unittest_io_state_conversions.cpp
+++ b/standalone/test/unit_tests/data_conversion_layer/unittest_io_state_conversions.cpp
@@ -87,8 +87,8 @@ TEST(IOStateConversionsTest, shouldReturnFalseForUnusedInputBit)
 
 TEST(IOStateConversionsTest, shouldReturnTrueForUsedInputBit)
 {
-  ASSERT_NE(data_conversion_layer::monitoring_frame::io::getInputType(0, 0), LogicalInputType::unused);
-  EXPECT_TRUE(data_conversion_layer::isUsedInputBit(0, 0));
+  ASSERT_NE(data_conversion_layer::monitoring_frame::io::getInputType(4, 1), LogicalInputType::unused);
+  EXPECT_TRUE(data_conversion_layer::isUsedInputBit(4, 1));
 }
 
 TEST(IOStateConversionsTest, shouldReturnFalseForUnusedOutputBit)

--- a/test/integration_tests/integrationtest_ros_scanner_node.cpp
+++ b/test/integration_tests/integrationtest_ros_scanner_node.cpp
@@ -64,11 +64,11 @@ static constexpr std::chrono::seconds LOOP_END_TIMEOUT{ 4 };
 static constexpr std::chrono::seconds STOP_TIMEOUT{ 1 };
 
 static const psen_scan_v2_standalone::LaserScan::IOData IO_DATA1{ {
-    psen_scan_v2_standalone::IOState(createPinData({ 1, 0, 0, 0, 0, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
+    psen_scan_v2_standalone::IOState(createPinData({ 0, 0, 0, 0, 0, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
 } };
 static const psen_scan_v2_standalone::LaserScan::IOData IO_DATA2{
-  { psen_scan_v2_standalone::IOState(createPinData({ 1, 0, 0, 0, 64, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
-    psen_scan_v2_standalone::IOState(createPinData({ 1, 0, 0, 0, 64, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
+  { psen_scan_v2_standalone::IOState(createPinData({ 0, 0, 0, 0, 64, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
+    psen_scan_v2_standalone::IOState(createPinData({ 0, 0, 0, 0, 64, 0, 0, 0 }, { 6, 0, 0, 0 }), 0 /*timestamp*/),
     psen_scan_v2_standalone::IOState(createPinData({ 0, 0, 0, 0, 64, 0, 0, 0 }, { 1, 0, 0, 0 }), 0 /*timestamp*/) }
 };
 
@@ -303,14 +303,14 @@ TEST_F(RosScannerNodeTests, shouldLogChangedIOStates)
   {
     InSequence s;
     EXPECT_LOG_SHORT(INFO,
-                     "RosScannerNode: IOs changed, new input: {Zone Bit 0 = true}, new output: {INTERLOCK 1 = true, "
+                     "RosScannerNode: IOs changed, new input: {}, new output: {INTERLOCK 1 = true, "
                      "Safety 2 intrusion = true}")
         .Times(1);
     EXPECT_LOG_SHORT(INFO,
                      "RosScannerNode: IOs changed, new input: {Zone Set Switching Input 1 = true}, new output: {}")
         .Times(1);
     EXPECT_LOG_SHORT(INFO,
-                     "RosScannerNode: IOs changed, new input: {Zone Bit 0 = false}, new output: {Safety 1 intrusion = "
+                     "RosScannerNode: IOs changed, new input: {}, new output: {Safety 1 intrusion = "
                      "true, INTERLOCK 1 = false, Safety 2 intrusion = false}")
         .WillOnce(OpenBarrier(&changed_io_state_barrier));
   }

--- a/test/unit_tests/unittest_io_state_rosconversions.cpp
+++ b/test/unit_tests/unittest_io_state_rosconversions.cpp
@@ -52,7 +52,7 @@ TEST(IOStateRosConversionsTest, shouldAddTheCorrectNumberOfInputStates)
   psen_scan_v2_standalone::IOState io_state{};
   psen_scan_v2::IOState ros_message = toIOStateMsg(io_state, "some_frame");
 
-  ASSERT_EQ(ros_message.input.size(), 29u);
+  ASSERT_EQ(ros_message.input.size(), 21u);
 }
 
 TEST(IOStateRosConversionsTest, shouldAddTheCorrectNumberOfOutputStates)


### PR DESCRIPTION
## Description

Removes zoneset bits from IO data since its redundant to the active zoneset field

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] Perform hardware tests

</details>
