### PR TITLE
Inform about missing configuration confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ roslaunch psen_scan_v2 psen_scan_v2.lauch config_file:='full_path_to/example_con
 
 ```
 WARNING
-There is no verification this configuration matches the one actually loaded on the PSENscan device!
+There is no verification the configuration you created using the PSENscan configurator matches the one actually loaded on the PSENscan device!
 
-Please always make sure, to keep those configurations syncronized otherwise this visualization might be missleading!
+Please always make sure, to keep those configurations syncronized otherwise the published zoneset polygons might be wrong and cause confusing errors like missleading visualization or navigation results that can not be executed by your real hardware!
 ```
 
 If you want to use the configuration node in your launchfile add a section such as:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ You can try this out with:
 roslaunch psen_scan_v2 psen_scan_v2.lauch config_file:='full_path_to/example_config.xml'
 ```
 
+```
+WARNING
+There is no verification this configuration matches the one actually loaded on the PSENscan device!
+
+Please always make sure, to keep those configurations syncronized otherwise this visualization might be missleading!
+```
+
 If you want to use the configuration node in your launchfile add a section such as:
 
 ```

--- a/src/config_server_node.cpp
+++ b/src/config_server_node.cpp
@@ -36,7 +36,8 @@ ConfigServerNode::ConfigServerNode(ros::NodeHandle& nh, const char* config_file_
         "ConfigurationServer",
         "The configuration server doesn't verfiy the provided configuration file matches the one on the connected "
         "device! "
-        "Mismatching configurations can amongst other things lead to confusing errors in navigation and misleading visualization. "
+        "Mismatching configurations can amongst other things lead to confusing errors in navigation and misleading "
+        "visualization. "
         "You are using \"" +
             std::string(config_file_path) + "\" please make sure that is the one you intented to use.");
 

--- a/src/config_server_node.cpp
+++ b/src/config_server_node.cpp
@@ -32,6 +32,11 @@ ConfigServerNode::ConfigServerNode(ros::NodeHandle& nh, const char* config_file_
     auto zoneconfig = configuration::xml_config_parsing::parseFile(config_file_path);
     zoneset_pub_ = nh_.advertise<::psen_scan_v2::ZoneSetConfiguration>(DEFAULT_ZONESET_TOPIC, 1, true /*latched*/);
 
+    ROS_WARN_STREAM_NAMED(
+        "ConfigurationServer",
+        "The configuration server doesn't verfiy the provided config mathes the one on the connected hardware! "
+        "You are using \"" + std::string(config_file_path) + "\" please verfiy its validity.");
+
     zoneset_pub_.publish(toRosMsg(zoneconfig, frame_id));
   }
   // LCOV_EXCL_START

--- a/src/config_server_node.cpp
+++ b/src/config_server_node.cpp
@@ -35,7 +35,8 @@ ConfigServerNode::ConfigServerNode(ros::NodeHandle& nh, const char* config_file_
     ROS_WARN_STREAM_NAMED(
         "ConfigurationServer",
         "The configuration server doesn't verfiy the provided config mathes the one on the connected hardware! "
-        "You are using \"" + std::string(config_file_path) + "\" please verfiy its validity.");
+        "You are using \"" +
+            std::string(config_file_path) + "\" please verfiy its validity.");
 
     zoneset_pub_.publish(toRosMsg(zoneconfig, frame_id));
   }

--- a/src/config_server_node.cpp
+++ b/src/config_server_node.cpp
@@ -34,9 +34,11 @@ ConfigServerNode::ConfigServerNode(ros::NodeHandle& nh, const char* config_file_
 
     ROS_WARN_STREAM_NAMED(
         "ConfigurationServer",
-        "The configuration server doesn't verfiy the provided config mathes the one on the connected hardware! "
+        "The configuration server doesn't verfiy the provided configuration file matches the one on the connected "
+        "device! "
+        "Mismatching configurations can amongst other things lead to confusing errors in navigation and misleading visualization. "
         "You are using \"" +
-            std::string(config_file_path) + "\" please verfiy its validity.");
+            std::string(config_file_path) + "\" please make sure that is the one you intented to use.");
 
     zoneset_pub_.publish(toRosMsg(zoneconfig, frame_id));
   }


### PR DESCRIPTION
## Description

Adds a warning to the readme and config server node to inform the user about the possible mismatch of the loaded config and the one on the connected hardware.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~Public api function documentation~
- [x] ~Architecture documentation reflects actual code structure~
- [x] ~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~
- [x] ~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~CHANGELOG.rst updated~
- [x] ~Copyright headers~
- [x] ~Examples~

### Review Checklist
- [x] ~Soft- and hardware architecture (diagrams and description)~
- [x] ~Test review (test plan and individual test cases)~
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
- [x] ~Which dependent packages do have to be released simultaneously?~

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
