### PR TITLE
Separate Pin formating and revert formatRange lambda usage

### DIFF
--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -166,8 +166,8 @@ void ROSScannerNodeT<S>::publishChangedIOStates(const std::vector<psen_scan_v2_s
 
       PSENSCAN_INFO("RosScannerNode",
                     "IOs changed, new input: {}, new output: {}",
-                    util::formatRange(io.changedInputStates(last_io_state_), formatPinState),
-                    util::formatRange(io.changedOutputStates(last_io_state_), formatPinState));
+                    formatPinStates(io.changedInputStates(last_io_state_)),
+                    formatPinStates(io.changedOutputStates(last_io_state_)));
       last_io_state_ = io;
     }
   }

--- a/standalone/include/psen_scan_v2_standalone/io_state.h
+++ b/standalone/include/psen_scan_v2_standalone/io_state.h
@@ -55,6 +55,23 @@ inline std::string formatPinState(const PinState& pin)
   return fmt::format("{} = {}", pin.name(), pin.state());
 }
 
+//! @brief Formats a vector of PinStates
+inline std::string formatPinStates(const std::vector<PinState>& pins)
+{
+  std::stringstream strstr;
+  strstr << "{";
+  for (auto it = pins.begin(); std::next(it) < pins.end(); ++it)
+  {
+    strstr << formatPinState(*it) << ", ";
+  }
+  if (!pins.empty())
+  {
+    strstr << formatPinState(pins.back());
+  }
+  strstr << "}";
+  return strstr.str();
+}
+
 //! @brief Represents the set of all I/Os of the scanner and their states.
 class IOState
 {

--- a/standalone/include/psen_scan_v2_standalone/util/format_range.h
+++ b/standalone/include/psen_scan_v2_standalone/util/format_range.h
@@ -35,22 +35,17 @@ namespace util
  * \verbatim "{}" (Empty Range) \endverbatim
  */
 template <typename T>
-std::string formatRange(
-    const T& range,
-    std::string (*element_formatter)(
-        const typename T::value_type&) =  // prevents usage of std::function on ubuntu 18.04:
-                                          // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70570
-    [](const typename T::value_type& v) { return fmt::format("{}", v); })
+std::string formatRange(const T& range)
 {
   std::stringstream strstr;
   strstr << "{";
   for (auto it = range.begin(); std::next(it) < range.end(); ++it)
   {
-    strstr << element_formatter(*it) << ", ";
+    strstr << fmt::format("{}, ", *it);
   }
   if (range.begin() < range.end())
   {
-    strstr << element_formatter(*std::prev(range.end()));
+    strstr << fmt::format("{}", *std::prev(range.end()));
   }
   strstr << "}";
   return strstr.str();


### PR DESCRIPTION
## Description

These changes Fix hopefully the build error on the Ros build farm:
https://build.ros.org/job/Mbin_ubv8_uBv8__psen_scan_v2__ubuntu_bionic_arm64__binary/37/console

We could not reproduce this error locally so we could only gues the reason and fix based on the information provided.

Alternatives to this approach:
- Using ostream operator for PinState in Log of changed states.
Would result in something like "PinState(id = 1, name = Zone Bit 1, state = false)" rather than "Zone Bit 1 = false"
- Changing ostream operator.
Current formating would remove id from ostream and therefore would be less descriptive.
- Find some fmt format range possibility with lambda .
Has to work with fmt-4.0 and with what ever gcc version the buildfarm uses for melodic builds.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] Public api function documentation
- [x] Architecture documentation reflects actual code structure
- [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
- [x] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] CHANGELOG.rst updated
- [x] Copyright headers
- [x] Examples

### Review Checklist
- [x] Soft- and hardware architecture (diagrams and description)
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released? ASAP
- [x] Which dependent packages do have to be released simultaneously?

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [x] ~Perform hardware tests~

</details>
