### PR TITLE
Add clang-tidy as separate job

### DIFF
--- a/.github/workflows/ci_action_melodic.yml
+++ b/.github/workflows/ci_action_melodic.yml
@@ -19,6 +19,18 @@ jobs:
         env:
           ROS_REPO: testing
 
+  build_test_clang_tidy:
+    name: "clang tidy melodic"
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_REPO: testing
+          ROS_DISTRO: melodic
+          ADDITIONAL_DEBS: "clang-tidy libclang-dev"
+          CMAKE_ARGS: "-DCATKIN_ENABLE_CLANG_TIDY=true"
+
   main-repo:
     name: "Build + Test with Main Repo of melodic (http://packages.ros.org/ros/ubuntu)"
     runs-on: ubuntu-18.04

--- a/.github/workflows/ci_action_melodic.yml
+++ b/.github/workflows/ci_action_melodic.yml
@@ -30,6 +30,7 @@ jobs:
           ROS_DISTRO: melodic
           ADDITIONAL_DEBS: "clang-tidy libclang-dev"
           CMAKE_ARGS: "-DCATKIN_ENABLE_CLANG_TIDY=true"
+          NOT_TEST_BUILD: "true"
 
   main-repo:
     name: "Build + Test with Main Repo of melodic (http://packages.ros.org/ros/ubuntu)"

--- a/.github/workflows/ci_action_noetic.yml
+++ b/.github/workflows/ci_action_noetic.yml
@@ -3,10 +3,8 @@ name: CI-Noetic
 on: [push, pull_request]
 
 env:
-  ADDITIONAL_DEBS: "clang-tidy libclang-dev"
   CATKIN_LINT: true
   CATKIN_LINT_ARGS: '--strict'
-  CMAKE_ARGS: "-DCATKIN_ENABLE_CLANG_TIDY=true"
   ROS_DISTRO: noetic
 
 jobs:
@@ -18,6 +16,18 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_REPO: testing
+
+  build_test_clang_tidy:
+    name: "clang tidy noetic"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_REPO: testing
+          ROS_DISTRO: noetic
+          ADDITIONAL_DEBS: "clang-tidy libclang-dev"
+          CMAKE_ARGS: "-DCATKIN_ENABLE_CLANG_TIDY=true"
 
   main-repo:
     name: "Build + Test with Main Repo of noetic (http://packages.ros.org/ros/ubuntu)"

--- a/.github/workflows/ci_action_noetic.yml
+++ b/.github/workflows/ci_action_noetic.yml
@@ -28,6 +28,7 @@ jobs:
           ROS_DISTRO: noetic
           ADDITIONAL_DEBS: "clang-tidy libclang-dev"
           CMAKE_ARGS: "-DCATKIN_ENABLE_CLANG_TIDY=true"
+          NOT_TEST_BUILD: "true"
 
   main-repo:
     name: "Build + Test with Main Repo of noetic (http://packages.ros.org/ros/ubuntu)"


### PR DESCRIPTION
*Jobs using clang-tidy will use clang
*This way the other builds remain gcc builds
