### PR TITLE
Add author and urls to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <name>psen_scan_v2</name>
   <version>0.10.1</version>
   <description>ROS support for the Pilz laser scanner</description>
-  
+
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.doehn@pilz.de">Christian Döhn</maintainer>
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>
@@ -12,7 +12,6 @@
 
   <license>LGPLv3</license>
   
-  <url type="website">https://wiki.ros.org/psen_scan_v2</url>
   <url type="bugtracker">https://github.com/PilzDE/psen_scan_v2/issues</url>
   <url type="repository">https://github.com/PilzDE/psen_scan_v2</url>
   

--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,6 @@
   <version>0.10.1</version>
   <description>ROS support for the Pilz laser scanner</description>
   
-  <author>Pilz GmbH + Co. KG</author>
-
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.doehn@pilz.de">Christian Döhn</maintainer>
   <maintainer email="c.henkel@pilz.de">Christian Henkel</maintainer>
@@ -13,6 +11,14 @@
   <maintainer email="r.feistenauer@pilz.de">Richard Feistenauer</maintainer>
 
   <license>LGPLv3</license>
+  
+  <url type="website">https://wiki.ros.org/psen_scan_v2</url>
+  <url type="bugtracker">https://github.com/PilzDE/psen_scan_v2/issues</url>
+  <url type="repository">https://github.com/PilzDE/psen_scan_v2</url>
+  
+  <author>Pilz GmbH + Co. KG</author>
+
+
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>fmt</depend>

--- a/package.xml
+++ b/package.xml
@@ -3,6 +3,8 @@
   <name>psen_scan_v2</name>
   <version>0.10.1</version>
   <description>ROS support for the Pilz laser scanner</description>
+  
+  <author>Pilz GmbH & Co. KG</author>
 
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.doehn@pilz.de">Christian Döhn</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>0.10.1</version>
   <description>ROS support for the Pilz laser scanner</description>
   
-  <author>Pilz GmbH & Co. KG</author>
+  <author>Pilz GmbH + Co. KG</author>
 
   <maintainer email="a.gutenkunst@pilz.de">Alexander Gutenkunst</maintainer>
   <maintainer email="c.doehn@pilz.de">Christian Döhn</maintainer>


### PR DESCRIPTION
## Description
* Adds urls
* Fixes missing field in http://wiki.ros.org/psen_scan_v2

![missing_author](https://user-images.githubusercontent.com/29709121/151552994-f54b64c0-3386-4a85-b999-282efa97e7f1.PNG)
