### PR TITLE
Feature/add max retries parameter

### DIFF
--- a/include/psen_scan_v2/ros_scanner_node.h
+++ b/include/psen_scan_v2/ros_scanner_node.h
@@ -79,6 +79,7 @@ public:
 
 private:
   void laserScanCallback(const LaserScan& scan);
+  void errorCallback(const std::string& error_msg);
   void publishChangedIOStates(const std::vector<psen_scan_v2_standalone::IOState>& io_states);
 
 private:
@@ -119,7 +120,9 @@ ROSScannerNodeT<S>::ROSScannerNodeT(ros::NodeHandle& nh,
   : nh_(nh)
   , tf_prefix_(tf_prefix)
   , x_axis_rotation_(x_axis_rotation)
-  , scanner_(scanner_config, std::bind(&ROSScannerNodeT<S>::laserScanCallback, this, std::placeholders::_1))
+  , scanner_(scanner_config,
+             std::bind(&ROSScannerNodeT<S>::laserScanCallback, this, std::placeholders::_1),
+             std::bind(&ROSScannerNodeT<S>::errorCallback, this, std::placeholders::_1))
 {
   pub_scan_ = nh_.advertise<sensor_msgs::LaserScan>(topic, 1);
   pub_zone_ = nh_.advertise<std_msgs::UInt8>("active_zoneset", 1);
@@ -177,6 +180,13 @@ template <typename S>
 void ROSScannerNodeT<S>::terminate()
 {
   terminate_ = true;
+}
+
+template <typename S>
+void ROSScannerNodeT<S>::errorCallback(const std::string& error_msg)
+{
+  PSENSCAN_ERROR("RosScannerNode", error_msg);
+  terminate();
 }
 
 template <typename S>

--- a/standalone/include/psen_scan_v2_standalone/scanner_interface.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_interface.h
@@ -42,9 +42,12 @@ class IScanner
 public:
   //! @brief Represents the user-provided callback for processing incoming scan data.
   using LaserScanCallback = std::function<void(const LaserScan&)>;
+  using ErrorCallback = std::function<void(const std::string&)>;
 
 public:
-  IScanner(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback);
+  IScanner(const ScannerConfiguration& scanner_config,
+           const LaserScanCallback& laser_scan_callback,
+           const ErrorCallback& error_callback);
   virtual ~IScanner() = default;
 
 public:
@@ -63,14 +66,18 @@ protected:
   [[deprecated("use const LaserScanCallback& laserScanCallback() const instead")]] const LaserScanCallback&
   getLaserScanCallback() const;
   const LaserScanCallback& laserScanCallback() const;
+  const ErrorCallback& errorCallback() const;
 
 private:
   const ScannerConfiguration config_;
   const LaserScanCallback laser_scan_callback_;
+  const ErrorCallback error_callback_;
 };
 
-inline IScanner::IScanner(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback)
-  : config_(scanner_config), laser_scan_callback_(laser_scan_callback)
+inline IScanner::IScanner(const ScannerConfiguration& scanner_config,
+                          const LaserScanCallback& laser_scan_callback,
+                          const ErrorCallback& error_callback)
+  : config_(scanner_config), laser_scan_callback_(laser_scan_callback), error_callback_(error_callback)
 {
   if (!laser_scan_callback)
   {
@@ -86,6 +93,11 @@ inline const ScannerConfiguration& IScanner::config() const
 inline const IScanner::LaserScanCallback& IScanner::laserScanCallback() const
 {
   return laser_scan_callback_;
+}
+
+inline const IScanner::ErrorCallback& IScanner::errorCallback() const
+{
+  return error_callback_;
 }
 
 inline const ScannerConfiguration& IScanner::getConfig() const

--- a/standalone/include/psen_scan_v2_standalone/scanner_v2.h
+++ b/standalone/include/psen_scan_v2_standalone/scanner_v2.h
@@ -61,6 +61,9 @@ class ScannerV2 : public IScanner
 {
 public:
   ScannerV2(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback);
+  ScannerV2(const ScannerConfiguration& scanner_config,
+            const LaserScanCallback& laser_scan_callback,
+            const ErrorCallback& error_callback);
   ~ScannerV2() override;
 
 public:
@@ -81,6 +84,7 @@ private:
   void scannerStoppedCallback();
   void scannerStartErrorCallback(const std::string& error_msg);
   void scannerStopErrorCallback(const std::string& error_msg);
+  void scannerErrorCallback(const std::string& error_msg);
 
 private:
   using OptionalPromise = boost::optional<std::promise<void>>;

--- a/standalone/src/scanner_v2.cpp
+++ b/standalone/src/scanner_v2.cpp
@@ -38,8 +38,10 @@ std::unique_ptr<util::Watchdog> WatchdogFactory::create(const util::Watchdog::Ti
   return std::unique_ptr<util::Watchdog>(new util::Watchdog(timeout, timeout_callback));
 }
 
-ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback)
-  : IScanner(scanner_config, laser_scan_callback)
+ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config,
+                     const LaserScanCallback& laser_scan_callback,
+                     const ErrorCallback& error_callback)
+  : IScanner(scanner_config, laser_scan_callback, error_callback)
   , sm_(new ScannerStateMachine(IScanner::config(),
                                 // LCOV_EXCL_START
                                 // The following includes calls to std::bind which are not marked correctly
@@ -48,6 +50,7 @@ ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScan
                                 BIND_EVENT(ReplyReceiveError),
                                 std::bind(&ScannerV2::scannerStartErrorCallback, this, std::placeholders::_1),
                                 std::bind(&ScannerV2::scannerStopErrorCallback, this, std::placeholders::_1),
+                                std::bind(&ScannerV2::scannerErrorCallback, this, std::placeholders::_1),
                                 BIND_RAW_DATA_EVENT(RawMonitoringFrameReceived),
                                 BIND_EVENT(MonitoringFrameReceivedError),
                                 std::bind(&ScannerV2::scannerStartedCallback, this),
@@ -59,6 +62,11 @@ ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScan
 {
   const std::lock_guard<std::mutex> lock(member_mutex_);
   sm_->start();
+}
+
+ScannerV2::ScannerV2(const ScannerConfiguration& scanner_config, const LaserScanCallback& laser_scan_callback)
+  : ScannerV2(scanner_config, laser_scan_callback, NULL)
+{
 }
 
 ScannerV2::~ScannerV2()
@@ -137,6 +145,15 @@ void ScannerV2::scannerStopErrorCallback(const std::string& error_msg)
   PSENSCAN_INFO("ScannerController", "Scanner stop failed.");
   scanner_has_stopped_.value().set_exception(std::make_exception_ptr(std::runtime_error(error_msg)));
   scanner_has_stopped_ = boost::none;
+}
+
+void ScannerV2::scannerErrorCallback(const std::string& error_msg)
+{
+  PSENSCAN_INFO("ScannerController", "Scanner encountered a runtime error.");
+  if (IScanner::errorCallback())
+  {
+    IScanner::errorCallback()(error_msg);
+  }
 }
 
 }  // namespace psen_scan_v2_standalone

--- a/test/include/psen_scan_v2/scanner_mock.h
+++ b/test/include/psen_scan_v2/scanner_mock.h
@@ -30,8 +30,9 @@ class ScannerMock
 {
 public:
   ScannerMock(const psen_scan_v2_standalone::ScannerConfiguration& scanner_config,
-              const psen_scan_v2_standalone::protocol_layer::LaserScanCallback& laser_scan_callback)
-    : laser_scan_callback_(laser_scan_callback){};
+              const psen_scan_v2_standalone::protocol_layer::LaserScanCallback& laser_scan_callback,
+              const psen_scan_v2_standalone::protocol_layer::ErrorCallback& error_callback)
+    : laser_scan_callback_(laser_scan_callback), error_callback_(error_callback){};
 
   MOCK_METHOD0(start, std::future<void>());
   MOCK_METHOD0(stop, std::future<void>());
@@ -40,6 +41,7 @@ public:
 
 private:
   psen_scan_v2_standalone::protocol_layer::LaserScanCallback laser_scan_callback_;
+  psen_scan_v2_standalone::protocol_layer::ErrorCallback error_callback_;
 };
 
 inline void ScannerMock::invokeLaserScanCallback(const psen_scan_v2_standalone::LaserScan& scan)


### PR DESCRIPTION
## Description

These changes Fix the problem that the driver keeps waiting for monitoring frames even if the scanner had a power cycle, without the user really being able to react to it. 

This PR adds an error_callback which gets triggered for example when to many monitoring frames where missed.

---

<details>
<summary>PR Checklist</summary>

### Things to add, update or check by the maintainers before this PR can be merged.

- [ ] Public api function documentation
- [ ] Architecture documentation reflects actual code structure
- [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
- [ ] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
- [ ] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [ ] CHANGELOG.rst updated
- [ ] Copyright headers
- [ ] Examples

### Review Checklist
- [ ] Soft- and hardware architecture (diagrams and description)
- [ ] Test review (test plan and individual test cases)
- [ ] Documentation describes purpose of file(s) and responsibilities
- [ ] Code (coding rules, style guide)

### Release planning (please answer)
- [ ] When is the new feature released?
- [ ] Which dependent packages do have to be released simultaneously?

### Hardware tests
_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
- [ ] ~Perform hardware tests~

</details>
