### PR TITLE
CI: use windows-2019 environment

### DIFF
--- a/.github/workflows/ci_action_win_standalone.yml
+++ b/.github/workflows/ci_action_win_standalone.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: [windows-latest]
+    runs-on: [windows-2019]
 
     steps:
     - uses: actions/checkout@v2

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -62,7 +62,7 @@ An example application, which prints distance data to the screen, is built by de
 ### Build and install dependencies
 #### Visual Studio
 - Get Visual Studio from https://visualstudio.microsoft.com/de/
-- Building is currently tested under `Visual Studio 16 2019`
+- Building is currently tested under `Visual Studio 16 2019` on `Windows Server 2019`
 - Open `Visual Studio Developer Command Prompt`
 - Use this Console for the next steps
 


### PR DESCRIPTION
## Description

These changes fix latest build errors on windows-ci-standalone.

See:
https://github.com/PilzDE/psen_scan_v2/tree/main/standalone#get-started-on-windows
